### PR TITLE
configure.ac: enable_aosd="guess" is probably broken

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,7 +264,7 @@ dnl *** Audacious OSD plugin (pangocairo-based)
 AC_ARG_ENABLE(aosd,
     [  --disable-aosd          disable Audacious OSD plugin (default=enabled)],
     [enable_aosd=$enableval],
-    [enable_aosd="guess"]
+    [enable_aosd="yes"]
 )
 
 AC_ARG_ENABLE(aosd_xcomp,
@@ -273,7 +273,7 @@ AC_ARG_ENABLE(aosd_xcomp,
     [enable_aosd_xcomp="yes"]
 )
 
-if test "x$enable_aosd" = "xguess"; then
+if test "x$enable_aosd" = "xyes"; then
     have_aosd="yes"
     PKG_CHECK_MODULES(PANGO,[pango >= 1.14.7],,
         [have_aosd="no"
@@ -303,24 +303,8 @@ if test "x$enable_aosd" = "xguess"; then
         have_aosd_xcomp="no"
     fi
 else
-    if test "x$enable_aosd" = "xyes"; then
-        AC_MSG_RESULT([*** Audacious OSD plugin has been forcefully enabled ***])
-        have_aosd="yes"
-        if test "x$enable_aosd_xcomp" = "xyes"; then
-            have_aosd_xcomp="yes"
-            PKG_CHECK_MODULES(XCOMPOSITE, xcomposite,
-                [AC_DEFINE([HAVE_XCOMPOSITE],[],[X Composite extension available])],
-                [have_aosd_xcomp="no"
-                AC_MSG_RESULT([*** X Composite extension not found, composite support for Audacious OSD will not be compiled ***])]
-            )
-        else
-            AC_MSG_RESULT([*** X Composite support for Audacious OSD plugin disabled per user request ***])
-            have_aosd_xcomp="no"
-        fi
-    else
-        AC_MSG_RESULT([*** Audacious OSD plugin disabled per user request ***])
-        have_aosd="no"
-    fi
+    AC_MSG_RESULT([*** Audacious OSD plugin disabled per user request ***])
+    have_aosd="no"
 fi
 
 if test "x$have_aosd" = "xyes"; then


### PR DESCRIPTION
When I feed --enable-aosd to ./configure it says "Audacious OSD plugin has been forcefully enabled" and skips PKG_CHECK_MODULES for pango, cairo and libXrender. And when launched make gets to src/aosd and ld fails to link ghosd and ghosd-main saying it can't find references to functions from libX11 and libXrender. Here is what I'm talking about:http://paste.pocoo.org/raw/555808/ . I dug a little and found this commit that introduced enable_aosd=guess to configure.ac: baa6007f8a98dce912fc4d385f9954da16b595a2 . It's possible to workarounand it by ensuring --enable-aosd is never seen by ./configure . And I'm packaging audacious-plugins for a source-based distro Exherbo and the workaround doesn't look nice in the build script. :)

So I took baa6007f8a98dce912fc4d385f9954da16b595a2, reverse-applied it and tested: wfm.
