### PR TITLE
${datadir} -> ${datarootdir}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1045,7 +1045,7 @@ if test -z "$datadir"; then
 	datadir="${prefix}/share"
 fi
 
-localedir="$datadir/locale"
+localedir="$datarootdir/locale"
 AC_SUBST(localedir)
 
 AC_SUBST(EFFECT_PLUGINS)


### PR DESCRIPTION
Use ${datarootdir} instead of ${datadir} for data files that go
in directories which are shared with other apps.

```
modified:   configure.ac
```
