### PR TITLE
configure.ac: Rework optional dependency checking code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1060,7 +1060,7 @@ fi
 
 dnl *** End of all plugin checks ***
 
-plugindir=`pkg-config audacious --variable=plugin_dir`
+PKG_CHECK_VAR([plugindir], [audacious], [plugin_dir], [], [AC_MSG_ERROR([Cannot retrieve plugin_dir pkgconfig variable])])
 AC_SUBST(plugindir)
 
 dnl XXX


### PR DESCRIPTION
Now configure exists with error in case user has requested to enable certain feature but its dependency hasn't been found.

Also, use AS_HELP_STRING and ensure proper m4 quoting around it.

I did it because I was always compiling (I use Gentoo Linux) the plugins with --enable-ffaudio, and now when I replaced ffmpeg with libav in my system, it began to silently fail. If there was an error by configure time, I wouldn't have to wonder why audacious stopped playing wma files. I think my patch will save trouble for people in the future, if applied.
