### PR TITLE
alsa: Add support for mixer element indexes

### DIFF
--- a/src/alsa/alsa.c
+++ b/src/alsa/alsa.c
@@ -617,6 +617,7 @@ void alsa_open_mixer (void)
 
     snd_mixer_selem_id_alloca (& selem_id);
     snd_mixer_selem_id_set_name (selem_id, alsa_config_mixer_element);
+    snd_mixer_selem_id_set_index (selem_id, alsa_config_mixer_element_index);
     alsa_mixer_element = snd_mixer_find_selem (alsa_mixer, selem_id);
 
     if (alsa_mixer_element == NULL)

--- a/src/alsa/alsa.h
+++ b/src/alsa/alsa.h
@@ -74,6 +74,7 @@ void alsa_set_volume (int left, int right);
 
 /* config.c */
 extern char * alsa_config_pcm, * alsa_config_mixer, * alsa_config_mixer_element;
+extern unsigned alsa_config_mixer_element_index;
 extern int alsa_config_drop_workaround, alsa_config_drain_workaround,
  alsa_config_delay_workaround;
 


### PR DESCRIPTION
Some drivers register multiple mixer elements with the same name.
Make the plugin aware of mixer element indexes to tell such mixer
elements apart.
## 

Tested on a soundcard with two "PCM" mixer elements.

Verified to work:
- switching between elements with the same name
- switching between elements with different names
- controlling elements with unique name :)
- saving and restoring configuration
- reading v3.4 configuration (defaults to the first mixer element matching old configuration)
