### PR TITLE
mpg123: prefs added. FULL_SCAN can be changed by GUI.

### DIFF
--- a/src/mpg123/Makefile
+++ b/src/mpg123/Makefile
@@ -1,6 +1,6 @@
 PLUGIN = madplug${PLUGIN_SUFFIX}
 
-SRCS = mpg123.c
+SRCS = mpg123.c prefs.c
 
 include ../../buildsys.mk
 include ../../extra.mk

--- a/src/mpg123/prefs.c
+++ b/src/mpg123/prefs.c
@@ -1,0 +1,35 @@
+/*
+ * Audacious: Cross platform multimedia player
+ * Copyright (c) 2005-2014 Audacious Team
+ *
+ * Preferences GUI by Kamil Markiewicz
+ */
+
+
+#include "prefs.h"
+
+#include <audacious/misc.h>
+
+#define MPG_CFGID "mpg123"
+
+AudaciousMPG123Config mpg123cfg;
+
+static const char * const mpg123_defaults[] = {
+    "full_scan", "FALSE",
+NULL};
+
+
+bool_t mpg123_cfg_load (void)
+{
+    aud_config_set_defaults (MPG_CFGID, mpg123_defaults);
+
+    mpg123cfg.full_scan = aud_get_bool (MPG_CFGID, "full_scan");
+
+    return TRUE;
+}
+
+
+void mpg123_cfg_save (void)
+{
+    aud_set_bool (MPG_CFGID, "full_scan", mpg123cfg.full_scan);
+}

--- a/src/mpg123/prefs.h
+++ b/src/mpg123/prefs.h
@@ -1,0 +1,22 @@
+/*
+ * Audacious: Cross platform multimedia player
+ * Copyright (c) 2005-2014 Audacious Team
+ *
+ */
+
+
+#ifndef MPG123_PREFS_H
+#define MPG123_PREFS_H
+
+#include <libaudcore/core.h>
+
+typedef struct {
+	bool_t full_scan;     /* Set to read all frame headers when calculating file length */
+} AudaciousMPG123Config;
+
+extern AudaciousMPG123Config mpg123cfg;
+
+bool_t mpg123_cfg_load (void);
+void   mpg123_cfg_save (void);
+
+#endif /* MPG123_PREFS */


### PR DESCRIPTION
I changed FULL_SCAN definiton into setting in mpg123 plugin. I've done it, because I tried to fix bug #215. It still can calculate wrong length, but returns right time in some more cases.
