### PR TITLE
Make libsdl version selectible with --with-libsdl=VER.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -610,17 +610,47 @@ AC_ARG_ENABLE(sdlout,
  [AS_HELP_STRING([--disable-sdlout], [disable SDL output plugin])],
  [enable_sdlout=$enableval], [enable_sdlout=auto])
 
+if test "x$enable_sdlout" != "xno"; then
+    AC_ARG_WITH(libsdl,
+                [AS_HELP_STRING([--with-libsdl=VER], [select which SDL version to use. Set VER to 1 for libsdl1, to 2 for libsdl2. @<:@default=check@:>@])],
+                [case "x$withval" in
+                     x1) ;;
+                     x2) ;;
+                     x*) withval=check;;
+                 esac
+                 with_libsdl=$withval], [with_libsdl=check])
+fi
+
+libsdl1_min="1.2.11";
+libsdl2_min="2.0";
+
 have_sdlout=no
 if test "x$enable_sdlout" != "xno"; then
-    PKG_CHECK_MODULES([SDL], [sdl2 >= 2.0],
-       [have_sdlout=yes
-        OUTPUT_PLUGINS="$OUTPUT_PLUGINS sdlout"],
-       [PKG_CHECK_MODULES([SDL], [sdl >= 1.2.11],
+    if test "x$with_libsdl" = "xcheck"; then
+        PKG_CHECK_MODULES([SDL], [sdl2 >= $libsdl2_min],
            [have_sdlout=yes
             OUTPUT_PLUGINS="$OUTPUT_PLUGINS sdlout"],
-           [if test "x$enable_sdlout" = "xyes"; then
-               AC_MSG_ERROR([Cannot find SDL development files (ver >= 1.2.11), but compilation of SDL output plugin has been explicitly requested; please install SDL dev files and run configure again])
-            fi])])
+           [PKG_CHECK_MODULES([SDL], [sdl >= $libsdl1_min],
+               [have_sdlout=yes
+                OUTPUT_PLUGINS="$OUTPUT_PLUGINS sdlout"],
+               [if test "x$enable_sdlout" = "xyes"; then
+                   AC_MSG_ERROR([Cannot find SDL development files (ver >= $libsdl1_min), but compilation of SDL output plugin has been explicitly requested; please install SDL dev files and run configure again])
+                fi])])
+    elif test "x$with_libsdl" = "x1"; then
+        PKG_CHECK_MODULES([SDL], [sdl >= $libsdl1_min],
+            [have_sdlout=yes
+             OUTPUT_PLUGINS="$OUTPUT_PLUGINS sdlout"],
+            [if test "x$enable_sdlout" = "xyes"; then
+                 AC_MSG_ERROR([Cannot find SDL1 development files (ver >= $libsdl1_min), but compilation of SDL output plugin has been explicitly requested; please install SDL1 dev files and run configure again])
+             fi])
+    elif test "x$with_libsdl" = "x2"; then
+        PKG_CHECK_MODULES([SDL], [sdl2 >= $libsdl2_min],
+            [have_sdlout=yes
+             OUTPUT_PLUGINS="$OUTPUT_PLUGINS sdlout"],
+            [if test "x$enable_sdlout" = "xyes"; then
+                 AC_MSG_ERROR([Cannot find SDL2 development files (ver >= $libsdl2_min), but compilation of SDL output plugin has been explicitly requested; please install SDL2 dev files and run configure again])
+             fi])
+    fi
 fi
 
 dnl *** sndio output


### PR DESCRIPTION
Defaults to "check", so the default behavior is compatible to how
audacious checked for SDL before.
