### PR TITLE
AOSD: Some minor tweaks (permanent title, also when paused)

### DIFF
--- a/src/aosd/aosd_osd.c
+++ b/src/aosd/aosd_osd.c
@@ -297,7 +297,11 @@ aosd_osd_create ( void )
   osd_data->fade_data.deco_code = osd_data->cfg_osd->decoration.code;
   osd_data->dalpha_in = 1.0 / ( osd_data->cfg_osd->animation.timing_fadein / (gfloat)AOSD_TIMING );
   osd_data->dalpha_out = 1.0 / ( osd_data->cfg_osd->animation.timing_fadeout / (gfloat)AOSD_TIMING );
-  osd_data->ddisplay_stay = 1.0 / ( osd_data->cfg_osd->animation.timing_display / (gfloat)AOSD_TIMING );
+  if (osd_data->cfg_osd->animation.timing_display) {
+      osd_data->ddisplay_stay = 1.0 / ( osd_data->cfg_osd->animation.timing_display / (gfloat)AOSD_TIMING );
+  } else {
+      osd_data->ddisplay_stay = 0;
+  }
   ghosd_set_render( osd , (GhosdRenderFunc)aosd_fade_func , &(osd_data->fade_data) , NULL );
 
   /* show the osd (with alpha 0, invisible) */

--- a/src/aosd/aosd_trigger.c
+++ b/src/aosd/aosd_trigger.c
@@ -277,10 +277,27 @@ aosd_trigger_func_pb_pauseon_onoff ( gboolean turn_on )
 static void
 aosd_trigger_func_pb_pauseon_cb ( gpointer unused1 , gpointer unused2 )
 {
-  char * markup = g_markup_printf_escaped ("<span font_desc='%s'>Paused</span>",
-   global_config->osd->text.fonts_name[0]);
+  gint active = aud_playlist_get_active();
+  gint pos = aud_playlist_get_position(active);
+  gint time_cur, time_tot;
+  gint time_cur_m, time_cur_s, time_tot_m, time_tot_s;
+
+  time_tot = aud_playlist_entry_get_length (active, pos, FALSE) / 1000;
+  time_cur = aud_drct_get_time() / 1000;
+  time_cur_s = time_cur % 60;
+  time_cur_m = (time_cur - time_cur_s) / 60;
+  time_tot_s = time_tot % 60;
+  time_tot_m = (time_tot - time_tot_s) / 60;
+
+  char * title = aud_playlist_entry_get_title (active, pos, FALSE);
+  char * markup = g_markup_printf_escaped
+   ("<span font_desc='%s'>%s (%i:%02i) [Paused: %i:%02i]</span>",
+   global_config->osd->text.fonts_name[0], title, time_tot_m, time_tot_s,
+   time_cur_m, time_cur_s);
+
   aosd_osd_display (markup, global_config->osd, FALSE);
   g_free (markup);
+  str_unref (title);
 }
 
 

--- a/src/aosd/aosd_ui.c
+++ b/src/aosd/aosd_ui.c
@@ -275,7 +275,7 @@ aosd_ui_configure_animation_timing ( gchar * label_string )
   GtkWidget *hbox, *desc_label, *spinbt;
   hbox = gtk_box_new( GTK_ORIENTATION_HORIZONTAL , 4 );
   desc_label = gtk_label_new( label_string );
-  spinbt = gtk_spin_button_new_with_range( 0 , 99999 , 1 );
+  spinbt = gtk_spin_button_new_with_range( 0 , 9999999 , 1 );
   gtk_box_pack_start( GTK_BOX(hbox) , desc_label , FALSE , FALSE , 0 );
   gtk_box_pack_start( GTK_BOX(hbox) , spinbt , FALSE , FALSE , 0 );
   g_object_set_data( G_OBJECT(hbox) , "spinbt" , spinbt );


### PR DESCRIPTION
Hi all,

I always missed the possibility to have a permanent on-screen information so I just added it.

Also I didn't see the advantage of not knowing which title was paused, so I changed that, too, showing a "Paused" hint and the current position.

Feel free to integrate it, if it seems ok, I'm using it and it for me it works :-)

(only directly after start the OSD isn't shown which I might address later).

So long
