### PR TITLE
Allow excluding album name from desktop notifications

### DIFF
--- a/src/notify/event.cc
+++ b/src/notify/event.cc
@@ -83,7 +83,7 @@ static void playback_update (void)
     String message;
     if (artist)
     {
-        if (album)
+        if (album && aud_get_bool ("notify", "album"))
             message = String (str_printf ("%s\n%s", (const char *) artist, (const char *) album));
         else
             message = artist;

--- a/src/notify/notify.cc
+++ b/src/notify/notify.cc
@@ -48,6 +48,7 @@ static const char plugin_about[] =
 static const char * const notify_defaults[] = {
  "actions", "TRUE",
  "resident", "FALSE",
+ "album", "TRUE",
  nullptr
 };
 
@@ -83,7 +84,9 @@ static const PreferencesWidget prefs_widgets[] = {
     WidgetCheck (N_("Show playback controls"),
         WidgetBool ("notify", "actions", plugin_reinit)),
     WidgetCheck (N_("Always show notification"),
-        WidgetBool ("notify", "resident", plugin_reinit))
+        WidgetBool ("notify", "resident", plugin_reinit)),
+    WidgetCheck (N_("Include album name in notification"),
+        WidgetBool ("notify", "album", plugin_reinit))
 };
 
 static const PluginPreferences plugin_prefs = {{prefs_widgets}};

--- a/src/notify/osd.cc
+++ b/src/notify/osd.cc
@@ -35,6 +35,7 @@ static void show_cb (void)
 static void osd_setup (NotifyNotification *notification)
 {
     gboolean resident = aud_get_bool ("notify", "resident");
+    gboolean album = aud_get_bool ("notify", "album");
 
     notify_notification_set_hint (notification, "desktop-entry",
      g_variant_new_string ("audacious"));
@@ -42,6 +43,7 @@ static void osd_setup (NotifyNotification *notification)
     notify_notification_set_hint (notification, "action-icons", g_variant_new_boolean (TRUE));
     notify_notification_set_hint (notification, "resident", g_variant_new_boolean (resident));
     notify_notification_set_hint (notification, "transient", g_variant_new_boolean (! resident));
+    notify_notification_set_hint (notification, "album", g_variant_new_boolean (album));
 
     notify_notification_set_urgency (notification, NOTIFY_URGENCY_LOW);
     notify_notification_set_timeout (notification, resident ?


### PR DESCRIPTION
Some desktop notification software doesn't parse newlines very well, e.g. dunst, where allowing '\n' causes a lot of dead space for me, and if you disable it, everything is on one line and harder to read. Also, some users might want this...maybe. I don't know. I do, anyway. It's a super small mod so I just did it instead of filing a request.

Note; this is ported from my modification to the debian package and works for me. Please ensure it works for you, I don't want to break anything.
