### PR TITLE
Added window type configuration

### DIFF
--- a/src/skins/menus.cc
+++ b/src/skins/menus.cc
@@ -116,6 +116,12 @@ static const AudguiMenuItem playlist_items[] = {
     MenuCommand (N_("Refresh Playlist"), "view-refresh", GDK_KEY_F5, NO_MOD, action_playlist_refresh_list)
 };
 
+static const AudguiMenuItem view_window_type[] = {
+    MenuCommand (N_("Default"), nullptr, NO_KEY, view_switch_type_default),
+    MenuCommand (N_("Desktop"), nullptr, NO_KEY, view_switch_type_desktop),
+    MenuCommand (N_("Dock"), nullptr, NO_KEY, view_switch_type_dock)
+};
+
 static const AudguiMenuItem view_items[] = {
     MenuToggle (N_("Show Playlist Editor"), nullptr, 'e', ALT, "skins", "playlist_visible", view_apply_show_playlist, "skins set playlist_visible"),
     MenuToggle (N_("Show Equalizer"), nullptr, 'g', ALT, "skins", "equalizer_visible", view_apply_show_equalizer, "skins set equalizer_visible"),
@@ -124,6 +130,7 @@ static const AudguiMenuItem view_items[] = {
     MenuSep (),
     MenuToggle (N_("Always on Top"), nullptr, 'o', CTRL, "skins", "always_on_top", view_apply_on_top, "skins set always_on_top"),
     MenuToggle (N_("On All Workspaces"), nullptr, 's', CTRL, "skins", "sticky", view_apply_sticky, "skins set sticky"),
+    MenuSub (N_("Window Type"), nullptr, view_window_type),
     MenuSep (),
     MenuToggle (N_("Roll Up Player"), nullptr, 'w', CTRL, "skins", "player_shaded", view_apply_player_shaded, "skins set player_shaded"),
     MenuToggle (N_("Roll Up Playlist Editor"), nullptr, 'w', SHIFT_CTRL, "skins", "playlist_shaded", view_apply_playlist_shaded, "skins set playlist_shaded"),

--- a/src/skins/skins_cfg.cc
+++ b/src/skins/skins_cfg.cc
@@ -77,6 +77,7 @@ static const char * const skins_defaults[] = {
  "playlist_width", "275",
  "playlist_height", "232",
  "sticky", "FALSE",
+ "window_type", "default",
  nullptr};
 
 skins_cfg_t config;

--- a/src/skins/ui_skinned_window.cc
+++ b/src/skins/ui_skinned_window.cc
@@ -19,6 +19,9 @@
  * using our public API to be a derived work.
  */
 
+#include <libaudcore/runtime.h>
+#include <string.h>
+
 #include "draw-compat.h"
 #include "skins_cfg.h"
 #include "ui_dock.h"
@@ -100,6 +103,8 @@ static void window_destroy (GtkWidget * window)
 GtkWidget * window_new (int * x, int * y, int w, int h, gboolean main,
  gboolean shaded, void (* draw) (GtkWidget * window, cairo_t * cr))
 {
+    String type = aud_get_str ("skins", "window_type");
+
     w *= config.scale;
     h *= config.scale;
 
@@ -128,6 +133,19 @@ GtkWidget * window_new (int * x, int * y, int w, int h, gboolean main,
 
     data->shaded = gtk_fixed_new ();
     g_object_ref (data->shaded);
+
+    if (!strcmp(type, "dock"))
+    {
+        gtk_window_set_type_hint ((GtkWindow *) window, GDK_WINDOW_TYPE_HINT_DOCK);
+        gtk_window_set_skip_taskbar_hint ((GtkWindow *) window, TRUE);
+        gtk_window_set_skip_pager_hint ((GtkWindow *) window, TRUE);
+    }
+    else if (!strcmp(type, "desktop"))
+    {
+        gtk_window_set_type_hint ((GtkWindow *) window, GDK_WINDOW_TYPE_HINT_DESKTOP);
+        gtk_window_set_skip_taskbar_hint ((GtkWindow *) window, TRUE);
+        gtk_window_set_skip_pager_hint ((GtkWindow *) window, TRUE);
+    }
 
     if (shaded)
         gtk_container_add ((GtkContainer *) window, data->shaded);

--- a/src/skins/view.cc
+++ b/src/skins/view.cc
@@ -23,6 +23,7 @@
 
 #include <libaudcore/runtime.h>
 #include <libaudcore/hook.h>
+#include <string.h>
 
 #include "plugin.h"
 #include "plugin-window.h"
@@ -223,4 +224,35 @@ void view_set_show_remaining (bool remaining)
 void view_apply_show_remaining (void)
 {
     mainwin_update_song_info ();
+}
+
+void view_switch_type_default (void)
+{
+    aud_set_str ("skins", "window_type", "default");
+    skins_restart ();
+}
+
+void view_switch_type_desktop (void)
+{
+    String type = aud_get_str ("skins", "window_type");
+
+    if (strcmp (type, "desktop"))
+        aud_set_str ("skins", "window_type", "desktop");
+    else
+        aud_set_str ("skins", "window_type", "default");
+
+    skins_restart ();
+}
+
+void view_switch_type_dock (void)
+{
+    String type = aud_get_str ("skins", "window_type");
+
+    if (strcmp (type, "dock"))
+        aud_set_str ("skins", "window_type", "dock");
+    else
+        aud_set_str ("skins", "window_type", "default");
+
+    skins_restart ();
+    
 }

--- a/src/skins/view.h
+++ b/src/skins/view.h
@@ -51,4 +51,10 @@ void view_apply_sticky (void);
 void view_set_show_remaining (bool remaining);
 void view_apply_show_remaining (void);
 
+void view_switch_type_default (void);
+
+void view_switch_type_desktop (void);
+
+void view_switch_type_dock (void);
+
 #endif /* SKINS_VIEW_H */


### PR DESCRIPTION
I usually keep Audacious as an "Above others" window on the edge of the screen, but disliked when it got iconified (eg. when using Ctrl + D, or minimize all windows). So I added a sub-menu to choose the window type when using the Winamp Classic Interface. Options are:
-Dock: Remove window from pager and taskbar and create it as a dock (above others and won't be ever iconified).
-Desktop: Remove from pager and taskbar. Create it as a desktop window (keep under other windows and never iconify).

Window Managers usually ignore changes to the window type after windows have been created, so a skins_restart () is required.

Bugs:
When using a Dock type window, the window doesn't receive keyboard focus. Tested under Openbox, I don't know if all WMs behave this way. I tried forcing focus using xdotool instead and it didn't work either. It would be great if someone had a solution.
