### PR TITLE
Fix scrobbler2 network problem (issue #618)

### DIFF
--- a/src/scrobbler2/scrobbler_communication.cc
+++ b/src/scrobbler2/scrobbler_communication.cc
@@ -122,6 +122,7 @@ static gboolean send_message_to_lastfm (const char * data)
 {
     AUDDBG("This message will be sent to last.fm:\n%s\n%%%%End of message%%%%\n", data);//Enter?\n", data);
     curl_easy_setopt(curlHandle, CURLOPT_POSTFIELDS, data);
+    curl_easy_setopt(curlHandle, CURLOPT_SSLVERSION, CURL_SSLVERSION_SSLv3);
     CURLcode curl_requests_result = curl_easy_perform(curlHandle);
 
     if (curl_requests_result != CURLE_OK) {
@@ -213,8 +214,8 @@ static gboolean scrobbler_test_connection() {
         return true;
     }
 
-    String testmsg = create_message_to_lastfm ("user.getRecommendedArtists", 3,
-     "limit", "1", "api_key", SCROBBLER_API_KEY,
+    String testmsg = create_message_to_lastfm ("user.getInfo", 2,
+     "api_key", SCROBBLER_API_KEY,
      "sk", (const char *) session_key);
 
     gboolean success = send_message_to_lastfm(testmsg);

--- a/src/scrobbler2/scrobbler_xml_parsing.cc
+++ b/src/scrobbler2/scrobbler_xml_parsing.cc
@@ -208,7 +208,7 @@ gboolean read_authentication_test_result (String &error_code, String &error_deta
         result = false;
 
     } else {
-        username = get_attribute_value("/lfm/recommendations[@user]", "user");
+        username = get_node_string("/lfm/user/name");
         if (!username) {
           AUDDBG("last.fm not answering according to the API.\n");
           result = false;


### PR DESCRIPTION
When the network check was performed, the server was returning a SSL Error "Illegal Parameter (47)", which seems to be an OpenSSL/curl bug [1]. To avoid this bug I enabled SSLv3 for the scrobbler
connection. Following this change the Last.fm server responded but it didn't know the "user.getRecommendedArtists" API method (it is not present in the current API [2]). I changed the tester method to "user.getInfo" and parsed the "username" received from the Last.fm server.

[1] https://bugs.launchpad.net/ubuntu/+source/curl/+bug/595415
[2] http://www.last.fm/api/intro
