### PR TITLE
configure: use correct logic for flac filewriter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -604,7 +604,7 @@ if test "x$enable_filewriter" = "xyes" -a "x$have_vorbis" = "xyes"; then
     FILEWRITER_LIBS="$FILEWRITER_LIBS $VORBIS_LIBS"
 fi
 
-if test "x$enable_filewriter" = "xyes" -a "x$have_flac" != "xyes"; then
+if test "x$enable_filewriter" = "xyes" -a "x$have_flac" = "xyes"; then
     AC_DEFINE(FILEWRITER_FLAC, 1, [Define if FLAC output part should be built])
     FILEWRITER_CFLAGS="$FILEWRITER_CFLAGS $LIBFLAC_CFLAGS"
     FILEWRITER_LIBS="$FILEWRITER_LIBS $LIBFLAC_LIBS"


### PR DESCRIPTION
Otherwise it tries to use the flac filewriter when flac isn't available.

Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>