### PR TITLE
Plugin to switch ReplayGain Album/Track mode based on playlist order.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -624,8 +624,6 @@ if test "x$enable_mac_media_keys" != "xno"; then
     GENERAL_PLUGINS="$GENERAL_PLUGINS mac-media-keys"
 fi
 
-dnl *** End of all plugin checks ***
-
 dnl rgswitch
 
 AC_ARG_ENABLE(rgswitch,
@@ -635,6 +633,8 @@ AC_ARG_ENABLE(rgswitch,
 if test "x$enable_rgswitch" != "xno"; then
     GENERAL_PLUGINS="$GENERAL_PLUGINS rgswitch"
 fi
+
+dnl *** End of all plugin checks ***
 
 plugindir=`pkg-config audacious --variable=plugin_dir`
 AC_SUBST(plugindir)

--- a/configure.ac
+++ b/configure.ac
@@ -626,6 +626,16 @@ fi
 
 dnl *** End of all plugin checks ***
 
+dnl rgswitch
+
+AC_ARG_ENABLE(rgswitch,
+ [AS_HELP_STRING([--disable-rgswitch], [disable ReplayGain Switch])],
+ [enable_rgswitch=$enableval], [enable_rgswitch="yes"])
+
+if test "x$enable_rgswitch" != "xno"; then
+    GENERAL_PLUGINS="$GENERAL_PLUGINS rgswitch"
+fi
+
 plugindir=`pkg-config audacious --variable=plugin_dir`
 AC_SUBST(plugindir)
 
@@ -769,6 +779,7 @@ echo "  GNOME Shortcuts:                        $have_gnomeshortcuts"
 echo "  libnotify OSD:                          $have_notify"
 echo "  Linux Infrared Remote Control (LIRC):   $have_lirc"
 echo "  MPRIS 2 Server:                         $have_mpris2"
+echo "  ReplayGain Switch:                      $enable_rgswitch"
 echo "  Scrobbler 2.0:                          $have_scrobbler2"
 echo "  Song Change:                            $have_songchange"
 echo

--- a/src/rgswitch/Makefile
+++ b/src/rgswitch/Makefile
@@ -1,0 +1,11 @@
+PLUGIN = rgswitch${PLUGIN_SUFFIX}
+SRCS = rgswitch.cc
+
+include ../../buildsys.mk
+include ../../extra.mk
+
+plugindir := ${plugindir}/${GENERAL_PLUGIN_DIR}
+
+LD = ${CXX}
+CFLAGS += ${PLUGIN_CFLAGS}
+CPPFLAGS += ${PLUGIN_CPPFLAGS} -I../..

--- a/src/rgswitch/rgswitch.cc
+++ b/src/rgswitch/rgswitch.cc
@@ -1,0 +1,88 @@
+/**
+ * Switches ReplayGain mode based on playback order.
+ * Uses Album ReplayGain for Sequential or Shuffle by Album playback order.
+ * Uses Track ReplayGain for Shuffle playback order.
+ *
+ * Copyright (C) 2016  kevinlekiller
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libaudcore/i18n.h>
+#include <libaudcore/hook.h>
+#include <libaudcore/plugin.h>
+#include <libaudcore/runtime.h>
+
+class ReplayGainSwitch : public GeneralPlugin
+{
+public:
+    static const char about[];
+    static constexpr PluginInfo info = {
+            N_("ReplayGain Switch"),
+            PACKAGE,
+            about
+    };
+
+    constexpr ReplayGainSwitch () : GeneralPlugin (info, true) {}
+
+    bool init ();
+    void cleanup ();
+};
+
+EXPORT ReplayGainSwitch aud_plugin_instance;
+
+static void set_rg_mode(void *, void *) {
+    /*
+     * Use track gain if shuffle is on.
+     * Use album gain if shuffle is off.
+     * Use album gain if shuffle is on and album shuffle is on.
+     */
+    aud_set_bool(
+        nullptr,
+        "replay_gain_album",
+        ! (aud_get_bool(nullptr, "shuffle") && ! aud_get_bool(nullptr, "album_shuffle"))
+    );
+}
+
+bool ReplayGainSwitch::init () {
+    // Set initially.
+    set_rg_mode(nullptr, nullptr);
+    // Check every time shuffle or album_shuffle is changed.
+    hook_associate("set shuffle", set_rg_mode, nullptr);
+    hook_associate("set album_shuffle", set_rg_mode, nullptr);
+    return true;
+}
+
+void ReplayGainSwitch::cleanup () {
+    hook_dissociate("set shuffle", set_rg_mode);
+    hook_dissociate("set album_shuffle", set_rg_mode);
+}
+
+const char ReplayGainSwitch::about[] = N_(
+    "ReplayGain Switch\n\n"
+    "Switches ReplayGain mode based on playback order.\n"
+    "Uses Album ReplayGain for Sequential or Shuffle by Album playback order.\n"
+    "Uses Track ReplayGain for Shuffle playback order.\n\n"
+    "Copyright (C) 2016  kevinlekiller\n\n"
+    "This program is free software: you can redistribute it and/or modify\n"
+    "it under the terms of the GNU General Public License as published by\n"
+    "the Free Software Foundation, either version 3 of the License, or\n"
+    "(at your option) any later version.\n\n"
+    "This program is distributed in the hope that it will be useful,\n"
+    "but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+    "GNU General Public License for more details.\n\n"
+    "You should have received a copy of the GNU General Public License\n"
+    "along with this program.  If not, see <http://www.gnu.org/licenses/>.\n"
+);


### PR DESCRIPTION
Turns on ReplayGain Album mode if Shuffle is off, or Shuffle is on and Album Shuffle if on.

Turns off ReplayGain Album mode if Shuffle is on.