### PR TITLE
remove hide/restore toggle in Qt systray

### DIFF
--- a/src/statusicon-qt/statusicon.cc
+++ b/src/statusicon-qt/statusicon.cc
@@ -169,8 +169,3 @@ void StatusIcon::toggle_aud_ui ()
 {
     aud_ui_show (! aud_ui_is_shown ());
 }
-
-void StatusIcon::update_menu ()
-{
-    QList< QAction *> acts = menu->actions ();
-}

--- a/src/statusicon-qt/statusicon.cc
+++ b/src/statusicon-qt/statusicon.cc
@@ -82,9 +82,6 @@ const PluginPreferences StatusIcon::prefs = {{widgets}};
 
 const audqt::MenuItem StatusIcon::items[] =
 {
-    audqt::MenuCommand ({N_("_Hide"), "window-close"}, StatusIcon::toggle_aud_ui),
-    audqt::MenuCommand ({N_("_Restore"), "window-new"}, StatusIcon::toggle_aud_ui),
-    audqt::MenuSep (),
     audqt::MenuCommand ({N_("_Play"), "media-playback-start"}, aud_drct_play),
     audqt::MenuCommand ({N_("Paus_e"), "media-playback-pause"}, aud_drct_pause),
     audqt::MenuCommand ({N_("_Stop"), "media-playback-stop"}, aud_drct_stop),
@@ -176,7 +173,4 @@ void StatusIcon::toggle_aud_ui ()
 void StatusIcon::update_menu ()
 {
     QList< QAction *> acts = menu->actions ();
-
-    acts.at (0)->setVisible (aud_ui_is_shown ());
-    acts.at (1)->setVisible (! aud_ui_is_shown ());
 }

--- a/src/statusicon-qt/statusicon.cc
+++ b/src/statusicon-qt/statusicon.cc
@@ -56,7 +56,6 @@ public:
     static void activate (QSystemTrayIcon::ActivationReason);
     static void open_files ();
     static void toggle_aud_ui ();
-    static void update_menu ();
 };
 
 EXPORT StatusIcon aud_plugin_instance;
@@ -106,7 +105,6 @@ bool StatusIcon::init ()
     QObject::connect (tray, & QSystemTrayIcon::activated, activate);
     menu = audqt::menu_build (items);
     tray->setContextMenu (menu);
-    QObject::connect (menu, & QMenu::aboutToShow, update_menu);
     tray->show ();
 
     hook_associate ("window close", window_closed, nullptr);


### PR DESCRIPTION
The commit removes the Hide/Restore toggle in the Qt systray, making the Gtk and Qt menus consistent with each other. 