### PR TITLE
Update Ampache Browser library name to version 1.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -465,7 +465,7 @@ ENABLE_PLUGIN_WITH_DEP(ampache,
     auto,
     GENERAL,
     AMPACHE,
-    ampache_browser_0)
+    ampache_browser_1)
 
 ENABLE_PLUGIN_WITH_DEP(qtaudio,
     QtMultimedia output,


### PR DESCRIPTION
Hi, I have released version 1.0.0 of Ampache Browser library.  The name of the generated library file is now libampache_browser_1.so instead of libampache_browser_0.so.  This is adaptation configure.ac to reflect that change.  I should have named the library file with _1 suffix right from the start but better late than never.  Sorry for inconvenience.
