### PR TITLE
qtui: fix build with Qt 5.10

### DIFF
--- a/src/qtui/info_bar.cc
+++ b/src/qtui/info_bar.cc
@@ -257,8 +257,8 @@ void InfoBar::paintEvent (QPaintEvent *)
         if (d.title.text ().isNull () && ! d.orig_title.isNull ())
         {
             QFontMetrics metrics = p.fontMetrics ();
-            d.title = metrics.elidedText (d.orig_title, Qt::ElideRight,
-             width () - ps.VisWidth - ps.Height - ps.Spacing);
+            d.title = QStaticText(metrics.elidedText (d.orig_title, Qt::ElideRight,
+             width () - ps.VisWidth - ps.Height - ps.Spacing));
         }
 
         p.setPen (QColor (255, 255, 255));


### PR DESCRIPTION
Fixes "info_bar.cc:258:21: error: no viable overloaded '='"