### PR TITLE
Add "Description" to "Song Info" window for OGGV and FLAC files.

### DIFF
--- a/src/flac/metadata.cc
+++ b/src/flac/metadata.cc
@@ -165,6 +165,7 @@ bool FLACng::write_tuple(const char *filename, VFSFile &file, const Tuple &tuple
     insert_str_tuple_to_vc(vc_block, tuple, Tuple::AlbumArtist, "ALBUMARTIST");
     insert_str_tuple_to_vc(vc_block, tuple, Tuple::Genre, "GENRE");
     insert_str_tuple_to_vc(vc_block, tuple, Tuple::Comment, "COMMENT");
+    insert_str_tuple_to_vc(vc_block, tuple, Tuple::Description, "DESCRIPTION");
 
     insert_int_tuple_to_vc(vc_block, tuple, Tuple::Year, "DATE");
     insert_int_tuple_to_vc(vc_block, tuple, Tuple::Track, "TRACKNUMBER");
@@ -210,6 +211,7 @@ static void parse_comment (Tuple & tuple, const char * key, const char * value)
         {"ALBUMARTIST", Tuple::AlbumArtist},
         {"TITLE", Tuple::Title},
         {"COMMENT", Tuple::Comment},
+        {"DESCRIPTION", Tuple::Description},
         {"GENRE", Tuple::Genre}
     };
 

--- a/src/skins-qt/menus.cc
+++ b/src/skins-qt/menus.cc
@@ -194,7 +194,8 @@ static const audqt::MenuItem sort_items[] = {
     audqt::MenuCommand ({N_("By File Name")}, sort_filename),
     audqt::MenuCommand ({N_("By File Path")}, sort_path),
     audqt::MenuCommand ({N_("By Custom Title")}, sort_custom_title),
-    audqt::MenuCommand ({N_("By Comment")}, sort_comment)
+    audqt::MenuCommand ({N_("By Comment")}, sort_comment),
+    audqt::MenuCommand ({N_("By Description")}, sort_description)
 };
 
 static const audqt::MenuItem sort_selected_items[] = {
@@ -209,7 +210,8 @@ static const audqt::MenuItem sort_selected_items[] = {
     audqt::MenuCommand ({N_("By File Name")}, sort_sel_filename),
     audqt::MenuCommand ({N_("By File Path")}, sort_sel_path),
     audqt::MenuCommand ({N_("By Custom Title")}, sort_sel_custom_title),
-    audqt::MenuCommand ({N_("By Comment")}, sort_sel_comment)
+    audqt::MenuCommand ({N_("By Comment")}, sort_sel_comment),
+    audqt::MenuCommand ({N_("By Description")}, sort_description)
 };
 
 static const audqt::MenuItem playlist_sort_items[] = {

--- a/src/skins/menus.cc
+++ b/src/skins/menus.cc
@@ -201,7 +201,8 @@ static const AudguiMenuItem sort_items[] = {
     MenuCommand (N_("By File Name"), nullptr, NO_KEY, sort_filename),
     MenuCommand (N_("By File Path"), nullptr, NO_KEY, sort_path),
     MenuCommand (N_("By Custom Title"), nullptr, NO_KEY, sort_custom_title),
-    MenuCommand (N_("By Comment"), nullptr, NO_KEY, sort_comment)
+    MenuCommand (N_("By Comment"), nullptr, NO_KEY, sort_comment),
+    MenuCommand (N_("By Description"), nullptr, NO_KEY, sort_description)
 };
 
 static const AudguiMenuItem sort_selected_items[] = {
@@ -216,7 +217,8 @@ static const AudguiMenuItem sort_selected_items[] = {
     MenuCommand (N_("By File Name"), nullptr, NO_KEY, sort_sel_filename),
     MenuCommand (N_("By File Path"), nullptr, NO_KEY, sort_sel_path),
     MenuCommand (N_("By Custom Title"), nullptr, NO_KEY, sort_sel_custom_title),
-    MenuCommand (N_("By Comment"), nullptr, NO_KEY, sort_comment)
+    MenuCommand (N_("By Comment"), nullptr, NO_KEY, sort_comment),
+    MenuCommand (N_("By Description"), nullptr, NO_KEY, sort_description)
 };
 
 static const AudguiMenuItem playlist_sort_items[] = {

--- a/src/ui-common/menu-ops.cc
+++ b/src/ui-common/menu-ops.cc
@@ -38,6 +38,7 @@ void sort_path () { ACTIVE.sort_entries (Playlist::Path); }
 void sort_filename () { ACTIVE.sort_entries (Playlist::Filename); }
 void sort_custom_title () { ACTIVE.sort_entries (Playlist::FormattedTitle); }
 void sort_comment () { ACTIVE.sort_entries (Playlist::Comment); }
+void sort_description () { ACTIVE.sort_entries (Playlist::Description); }
 void sort_reverse () { ACTIVE.reverse_order (); }
 void sort_random () { ACTIVE.randomize_order (); }
 

--- a/src/ui-common/menu-ops.h
+++ b/src/ui-common/menu-ops.h
@@ -37,6 +37,7 @@ void sort_length ();
 void sort_path ();
 void sort_filename ();
 void sort_custom_title ();
+void sort_description ();
 void sort_comment ();
 void sort_reverse ();
 void sort_random ();

--- a/src/vorbis/vcupdate.cc
+++ b/src/vorbis/vcupdate.cc
@@ -98,6 +98,7 @@ bool VorbisPlugin::write_tuple (const char * filename, VFSFile & file, const Tup
     insert_str_tuple_field_to_dictionary (tuple, Tuple::Album, dict, "ALBUM");
     insert_str_tuple_field_to_dictionary (tuple, Tuple::AlbumArtist, dict, "ALBUMARTIST");
     insert_str_tuple_field_to_dictionary (tuple, Tuple::Comment, dict, "COMMENT");
+    insert_str_tuple_field_to_dictionary (tuple, Tuple::Description, dict, "DESCRIPTION");
     insert_str_tuple_field_to_dictionary (tuple, Tuple::Genre, dict, "GENRE");
 
     insert_int_tuple_field_to_dictionary (tuple, Tuple::Year, dict, "DATE");

--- a/src/vorbis/vorbis.cc
+++ b/src/vorbis/vorbis.cc
@@ -142,6 +142,7 @@ static void read_comment (vorbis_comment * comment, Tuple & tuple)
     set_tuple_str (tuple, Tuple::AlbumArtist, comment, "ALBUMARTIST");
     set_tuple_str (tuple, Tuple::Genre, comment, "GENRE");
     set_tuple_str (tuple, Tuple::Comment, comment, "COMMENT");
+    set_tuple_str (tuple, Tuple::Description, comment, "DESCRIPTION");
 
     if ((tmps = vorbis_comment_query (comment, "TRACKNUMBER", 0)))
         tuple.set_int (Tuple::Track, atoi (tmps));


### PR DESCRIPTION
There's an ongoing problem with sort menus not working right, but I feel it's time to get this pulled in now and allow others to address those sort menus.