### PR TITLE
Make mpris trackid type a dbus object path

### DIFF
--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -152,7 +152,7 @@ static void update_metadata (void * data, GObject * object)
     }
 
     GVariant * key = g_variant_new_string ("mpris:trackid");
-    GVariant * str = g_variant_new_string ("/org/mpris/MediaPlayer2/CurrentTrack");
+    GVariant * str = g_variant_new_object_path ("/org/mpris/MediaPlayer2/CurrentTrack");
     GVariant * var = g_variant_new_variant (str);
     elems[nelems ++] = g_variant_new_dict_entry (key, var);
 


### PR DESCRIPTION
Mpris Track_Id type should be a dbus object path, not a string.

https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Simple-Type:Track_Id