### PR TITLE
psf: Add ignore length option for endless looping

### DIFF
--- a/src/psf/peops/spu.cc
+++ b/src/psf/peops/spu.cc
@@ -194,10 +194,16 @@ int psf_seek(u32 t)
  return(0);
 }
 
+static int endless;
+void setendless(int e)
+{
+ endless=e;
+}
+
 // Counting to 65536 results in full volume offage.
 void setlength(s32 stop, s32 fade)
 {
- if(stop==~0)
+ if(stop==~0 || endless)
  {
   decaybegin=~0;
  }

--- a/src/psf/peops/spu.h
+++ b/src/psf/peops/spu.h
@@ -27,6 +27,7 @@
 void SPUirq(void);
 
 int psf_seek(uint32_t t);
+void setendless(int e);
 void setlength(int32_t stop, int32_t fade);
 
 int SPUasync(uint32_t cycles, void (*update)(const void *, int));

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -337,10 +337,16 @@ int psf2_seek(u32 t)
  return(0);
 }
 
+static int endless;
+void setendless2(int e)
+{
+ endless=e;
+}
+
 // Counting to 65536 results in full volume offage.
 void setlength2(s32 stop, s32 fade)
 {
- if(stop==~0)
+ if(stop==~0 || endless)
  {
   decaybegin=~0;
  }

--- a/src/psf/peops2/spu.h
+++ b/src/psf/peops2/spu.h
@@ -27,6 +27,7 @@
 //
 //*************************************************************************//
 
+void setendless2(int e);
 void setlength2(int32_t stop, int32_t fade);
 
 long SPU2init(void);

--- a/src/psf/plugin.cc
+++ b/src/psf/plugin.cc
@@ -30,7 +30,9 @@
 
 #include <libaudcore/i18n.h>
 #include <libaudcore/plugin.h>
+#include <libaudcore/preferences.h>
 #include <libaudcore/audstrings.h>
+#include <libaudcore/runtime.h>
 
 #include "ao.h"
 #include "corlett.h"
@@ -43,14 +45,22 @@ class PSFPlugin : public InputPlugin
 {
 public:
     static const char *const exts[];
+    static const char *const defaults[];
+    static const PreferencesWidget widgets[];
+    static const PluginPreferences prefs;
 
     static constexpr PluginInfo info = {
         N_("OpenPSF PSF1/PSF2 Decoder"),
-        PACKAGE
+        PACKAGE,
+        nullptr,
+        & prefs
+
     };
 
     constexpr PSFPlugin() : InputPlugin(info, InputInfo()
         .with_exts(exts)) {}
+
+    bool init();
 
     bool is_our_file(const char *filename, VFSFile &file);
     bool read_tag(const char *filename, VFSFile &file, Tuple &tuple, Index<char> *image);
@@ -83,6 +93,18 @@ static PSFEngineFunctors psf_functor_map[ENG_COUNT] = {
     {psf2_start, psf2_stop, psf2_seek, psf2_execute},
     {spx_start, spx_stop, psf_seek, spx_execute},
 };
+
+const char* const PSFPlugin::defaults[] =
+{
+    "ignore_length", "FALSE",
+    nullptr
+};
+
+bool PSFPlugin::init()
+{
+    aud_config_set_defaults("psf", defaults);
+    return true;
+}
 
 static PSFEngineFunctors *f;
 static String dirpath;
@@ -156,12 +178,20 @@ bool PSFPlugin::play(const char *filename, VFSFile &file)
 
     Index<char> buf = file.read_all ();
 
+    bool ignore_len = aud_get_bool("psf", "ignore_length");
+
     PSFEngine eng = psf_probe(buf.begin(), buf.len());
     if (eng == ENG_NONE || eng == ENG_COUNT)
     {
         error = true;
         goto cleanup;
     }
+
+    if(eng == ENG_PSF1 || eng == ENG_SPX)
+        setendless(ignore_len);
+
+    if(eng == ENG_PSF2)
+        setendless2(ignore_len);
 
     f = &psf_functor_map[eng];
 
@@ -234,3 +264,10 @@ bool PSFPlugin::is_our_file(const char *filename, VFSFile &file)
 }
 
 const char *const PSFPlugin::exts[] = { "psf", "minipsf", "psf2", "minipsf2", "spu", "spx", nullptr };
+
+const PreferencesWidget PSFPlugin::widgets[] = {
+    WidgetLabel(N_("<b>OpenPSF Configuration</b>")),
+    WidgetCheck(N_("Ignore length from file"), WidgetBool("psf", "ignore_length")),
+};
+
+const PluginPreferences PSFPlugin::prefs = {{widgets}};


### PR DESCRIPTION
This PR adds an option in the psf plugin to ignore the length of the tracks, resulting in endless looping.
It has been tested with psf and psf2 files. Other plugins have similar options.