### PR TITLE
Fix pulseaudio output plugin flushing.

### DIFF
--- a/src/pulse/pulse_audio.cc
+++ b/src/pulse/pulse_audio.cc
@@ -297,7 +297,7 @@ int PulseOutput::write_audio (const void * ptr, int length)
 
     length = aud::min ((size_t) length, pa_stream_writable_size (stream));
 
-    if (pa_stream_write (stream, ptr, length, nullptr, 0, PA_SEEK_RELATIVE) < 0)
+    if (pa_stream_write (stream, ptr, length, nullptr, 0, flushed ? PA_SEEK_RELATIVE_ON_READ : PA_SEEK_RELATIVE) < 0)
         REPORT ("pa_stream_write");
     else
         ret = length;


### PR DESCRIPTION
Currently the Pulseaudio output plugin does not flush output buffers, creating a latency on playback seek and skip. If the maximum buffer size of two seconds is chosen for interrupt reducing and therefore powersaving reasons, song seek and skip operations are delayed by two seconds.

This change fixes this buffer flushing. Calling pa_stream_flush before writing is not enough to flush both daemon and hardware buffers, the next write must also indicate that it should be positioned relative to just before the next read.

Pulseaudio Doxygen alludes to this: "Most of the time you're better off using the parameter seek of pa_stream_write() instead of [pa_stream_flush()]."