### PR TITLE
JACK: Additional settings for the auto-connect feature

### DIFF
--- a/src/jack/jack-ng.cc
+++ b/src/jack/jack-ng.cc
@@ -110,6 +110,10 @@ const char JACKOutput::client_name_default[] = "audacious";
 const char * const JACKOutput::defaults[] = {
     "auto_connect", "TRUE",
     "client_name", JACKOutput::client_name_default,
+    "ports_filter", "",
+    "ports_ignore", "FALSE",
+    "ports_physical", "TRUE",
+    "ports_upmix", "2",
     "volume_left", "100",
     "volume_right", "100",
     nullptr
@@ -119,7 +123,23 @@ const PreferencesWidget JACKOutput::widgets[] = {
     WidgetEntry (N_("Client name:"),
         WidgetString ("jack", "client_name")),
     WidgetCheck (N_("Automatically connect to output ports"),
-        WidgetBool ("jack", "auto_connect"))
+        WidgetBool ("jack", "auto_connect")),
+    WidgetLabel (N_("Filter ports (regex, use any port if blank):"),
+        WIDGET_CHILD),
+    WidgetEntry (nullptr,
+        WidgetString ("jack", "ports_filter"),
+        {false},
+        WIDGET_CHILD),
+    WidgetCheck (N_("Connect to physical ports only"),
+        WidgetBool ("jack", "ports_physical"),
+        WIDGET_CHILD),
+    WidgetSpin (N_("Upmix to"),
+        WidgetInt ("jack", "ports_upmix"),
+        {1, 96, 1, N_("ports if input has fewer channels")},
+        WIDGET_CHILD),
+    WidgetCheck (N_("Ignore insufficient number of ports"),
+        WidgetBool ("jack", "ports_ignore"),
+        WIDGET_CHILD)
 };
 
 const PluginPreferences JACKOutput::prefs = {{widgets}};
@@ -147,29 +167,38 @@ bool JACKOutput::connect_ports (int channels, String & error)
     const char * * ports = nullptr;
     int count = 0;
 
-    if (! (ports = jack_get_ports (m_client, nullptr, nullptr,
-     JackPortIsPhysical | JackPortIsInput)))
-    {
-        AUDERR ("jack_get_ports() failed\n");
-        goto fail;
-    }
+    unsigned long ports_flags = JackPortIsInput;
+    if (aud_get_bool ("jack", "ports_physical"))
+        ports_flags |= JackPortIsPhysical;
 
-    while (ports[count])
-        count ++;
+    if (! (ports = jack_get_ports (m_client, aud_get_str ("jack", "ports_filter"), nullptr, ports_flags)))
+    {
+        if (! aud_get_bool ("jack", "ports_ignore"))
+        {
+            error = String (_("No JACK output ports were found. Please check settings."));
+            goto fail;
+        }
+    }
+    else
+    {
+        while (ports[count])
+            count ++;
+    }
 
     if (count < channels)
     {
-        error = String (str_printf (_("Only %d JACK output ports were "
-         "found but %d are required."), count, channels));
-        goto fail;
+        if (! aud_get_bool ("jack", "ports_ignore"))
+        {
+            error = String (str_printf (_("Only %d JACK output ports were "
+            "found but %d are required."), count, channels));
+            goto fail;
+        }
+        else
+            AUDWARN ("Not enough output ports available. Playing %d of %d channels.\n", count, channels);
     }
 
-    // upmix mono to stereo
-    // for all other arrangements, use a one-to-one mapping
-    if (channels == 1)
-        count = aud::min (count, 2);
-    else
-        count = aud::min (count, channels);
+    // upmix
+    count = aud::min (count, aud::max (aud_get_int ("jack", "ports_upmix"), channels));
 
     for (int i = 0; i < count; i ++)
     {


### PR DESCRIPTION
To give the advanced user more control over the auto-connect feature of the JACK output plugin, I've added the following options:
- Select specific ports using a regular expression (e.g. "playback_[3,4]" to use the second pair of stereo channels of a multi-channel audio interface instead of the first).
- Allow non-physical ports to be used (like those opened by alsa_out or other processing clients).
- Specify a higher port count (than 2) for the "upmix" feature or set it to 1 to disable it (e.g. a port filter of "playback_[1,2,5,6]" and a channel count of 4 will route mono and stereo inputs to the front and rear channels of a surround sound interface). Of course, this will most likely only give useful results in cases where the port count is a multiple of the input channel count.
- Allow playback to start even if not all input channels could be connected to output ports (e.g. this would play the front channels of a surround file on a stereo interface, only generating a warning but not an error).

The default settings retain the previous behaviour.