### PR TITLE
Making pulse audio configurable

### DIFF
--- a/src/pulse/pulse_audio.cc
+++ b/src/pulse/pulse_audio.cc
@@ -28,8 +28,6 @@
 #include <libaudcore/threads.h>
 #include <libaudcore/preferences.h>
 
-#include <iostream>
-
 class PulseOutput : public OutputPlugin
 {
 public:


### PR DESCRIPTION
Currently, the context and stream names used by the PulseAudio audio plugin are hard-coded to "Audacious". Therefore, when running multiple instances, using the -1, -2 -,3, etc. options, these cannot be properly distinguished.

I've added a config option allowing to set an individual client name for each instance profile. To accommodate to more complex patchbay configurations, setting a custom client name might also be useful when running a single instance.

My main motivation is to be able to run two (or more) instances of Audacious and map the audio of each instance to a different sound card.