### PR TITLE
Fixing meson builds on mingw32

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,20 +15,23 @@ glib_dep = dependency('glib-2.0', version: glib_req, required: true)
 gmodule_dep = dependency('gmodule-2.0', version: glib_req, required: true)
 
 
+zlib_dep = dependency('zlib', required: true)
+
+
 audacious_req = '>= 3.11'
 audacious_dep = dependency('audacious', version: audacious_req, required: true)
 
 
 # XXX - make this it's own .pc file
 audtag_dep = declare_dependency(link_args: [
-  '-L@0@'.format(audacious_dep.get_pkgconfig_variable('libdir')),
+  '-L@0@'.format(audacious_dep.get_pkgconfig_variable('lib_dir')),
   '-laudtag'
 ])
 
 
 # XXX - make this it's own .pc file
 audqt_dep = declare_dependency(link_args: [
-  '-L@0@'.format(audacious_dep.get_pkgconfig_variable('libdir')),
+  '-L@0@'.format(audacious_dep.get_pkgconfig_variable('lib_dir')),
   '-laudqt'
 ])
 
@@ -122,7 +125,7 @@ elif cc.get_id() == 'gcc' or cc.get_id() == 'clang'
 endif
 
 
-install_plugindir = join_paths(get_option('libdir'), 'audacious')
+install_plugindir = audacious_dep.get_pkgconfig_variable('plugin_dir')
 
 
 conf.set_quoted('INSTALL_PLUGINDIR', install_plugindir)

--- a/src/config.h.meson
+++ b/src/config.h.meson
@@ -27,3 +27,5 @@
 #mesondefine FILEWRITER_MP3
 #mesondefine FILEWRITER_FLAC
 #mesondefine FILEWRITER_VORBIS
+
+#mesondefine HAVE_LIBCUE2

--- a/src/console/meson.build
+++ b/src/console/meson.build
@@ -1,6 +1,3 @@
-zlib_dep = dependency('zlib')
-
-
 gme_sources = [
   'Ay_Apu.cc',
   'Ay_Cpu.cc',
@@ -61,12 +58,10 @@ plugin_sources = [
 ]
 
 
-if zlib_dep.found()
-  shared_module('console',
-    gme_sources,
-    plugin_sources,
-    dependencies: [audacious_dep, zlib_dep],
-    install: true,
-    install_dir: input_plugin_dir
-  )
-endif
+shared_module('console',
+  gme_sources,
+  plugin_sources,
+  dependencies: [audacious_dep, zlib_dep],
+  install: true,
+  install_dir: input_plugin_dir
+)

--- a/src/psf/meson.build
+++ b/src/psf/meson.build
@@ -25,7 +25,7 @@ shared_module('psf',
   plugin_sources,
   peops_sources,
   peops2_sources,
-  dependencies: [audacious_dep],
+  dependencies: [audacious_dep, zlib_dep],
   install: true,
   install_dir: input_plugin_dir
 )

--- a/src/xsf/meson.build
+++ b/src/xsf/meson.build
@@ -24,7 +24,7 @@ desmume_sources = [
 shared_module('xsf',
   plugin_sources,
   desmume_sources,
-  dependencies: [audacious_dep],
+  dependencies: [audacious_dep, zlib_dep],
   install: true,
   install_dir: input_plugin_dir
 )


### PR DESCRIPTION
Meson builds are broken on mingw32 (and potentially other platforms).