### PR TITLE
Add HiDPI support to QT album art plugin

### DIFF
--- a/src/albumart-qt/albumart.cc
+++ b/src/albumart-qt/albumart.cc
@@ -17,6 +17,7 @@
  * the use of this software.
  */
 
+#include <QApplication>
 #include <QLabel>
 #include <QPixmap>
 
@@ -58,7 +59,7 @@ public:
     void update_art ()
     {
         origPixmap = QPixmap (audqt::art_request_current (0, 0));
-        qreal r = devicePixelRatioF();
+        qreal r = qApp->devicePixelRatio ();
         origPixmap.setDevicePixelRatio (r);
         origSize = origPixmap.size ();
         drawArt ();
@@ -101,7 +102,7 @@ private:
             origSize.height () <= size ().height() - MARGIN)
             setPixmap (origPixmap);
         else {
-            qreal r = devicePixelRatioF();
+            qreal r = qApp->devicePixelRatio ();
             setPixmap (origPixmap.scaled ((size ().width () - MARGIN) * r,
                                           (size ().height () - MARGIN) * r,
                                           Qt::KeepAspectRatio,

--- a/src/albumart-qt/albumart.cc
+++ b/src/albumart-qt/albumart.cc
@@ -98,14 +98,22 @@ private:
 
     void drawArt ()
     {
-        if (origSize.width () <= size ().width () - MARGIN &&
-            origSize.height () <= size ().height() - MARGIN)
+        qreal r = qApp->devicePixelRatio();
+        if (std::abs(r - 1.0) <= 0.01 &&
+            origSize.width () <= size ().width () - MARGIN &&
+            origSize.height () <= size ().height() - MARGIN) {
+            // If device pixel ratio is close to 1:1 (within 1%) and art is
+            // smaller than widget, set pixels directly w/o scaling
             setPixmap (origPixmap);
-        else {
-            qreal r = qApp->devicePixelRatio ();
-            setPixmap (origPixmap.scaled ((size ().width () - MARGIN) * r,
-                                          (size ().height () - MARGIN) * r,
-                                          Qt::KeepAspectRatio,
+        } else {
+            // Otherwise scale image with device pixel ratio, but limit size to
+            // widget dimensions.
+            auto width = std::min(r * (size().width() - MARGIN),
+                                  r * origSize.width());
+            auto height = std::min(r * (size().height() - MARGIN),
+                                   r * origSize.height());
+
+            setPixmap (origPixmap.scaled (width, height, Qt::KeepAspectRatio,
                                           Qt::SmoothTransformation));
         }
 

--- a/src/albumart-qt/albumart.cc
+++ b/src/albumart-qt/albumart.cc
@@ -58,6 +58,8 @@ public:
     void update_art ()
     {
         origPixmap = QPixmap (audqt::art_request_current (0, 0));
+        qreal r = devicePixelRatioF();
+        origPixmap.setDevicePixelRatio (r);
         origSize = origPixmap.size ();
         drawArt ();
     }
@@ -98,9 +100,13 @@ private:
         if (origSize.width () <= size ().width () - MARGIN &&
             origSize.height () <= size ().height() - MARGIN)
             setPixmap (origPixmap);
-        else
-            setPixmap (origPixmap.scaled (size ().width () - MARGIN, size ().height () - MARGIN,
-                        Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        else {
+            qreal r = devicePixelRatioF();
+            setPixmap (origPixmap.scaled ((size ().width () - MARGIN) * r,
+                                          (size ().height () - MARGIN) * r,
+                                          Qt::KeepAspectRatio,
+                                          Qt::SmoothTransformation));
+        }
 
 #ifdef Q_OS_MAC
 	repaint();


### PR DESCRIPTION
Made album art plugin be aware of device pixel ratio for drawing. Note that this can result in pretty small pictures if the album art is smaller than the pixbuf size. It might be worth scaling up pictures by the device pixel ratio for smaller images.