### PR TITLE
adplug: Fixing MAME renderer to play in both channels

### DIFF
--- a/src/adplug/adplug-xmms.cc
+++ b/src/adplug/adplug-xmms.cc
@@ -208,6 +208,8 @@ bool AdPlugXMMS::play (const char * filename, VFSFile & fd)
     case ADPLUG_MAME:
     default:
       opl.capture(new CEmuopl (freq, true, true));
+      // otherwise sound only comes out of left
+      static_cast<CEmuopl *>(opl.get())->settype(Copl::TYPE_OPL2);
   }
 
   long toadd = 0, i, towrite;


### PR DESCRIPTION
When toying a bit more with the adplug MAME renderer, I noted while wearing headphones that the output only came from the left channel. This PR fixes the issue.