### PR TITLE
When bitrate is CBR use bitrate, if not try to calculate it.

### DIFF
--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -251,8 +251,8 @@ static bool read_mpg123_info (const char * filename, VFSFile & file, Tuple & tup
         return false;
 
     tuple.set_str (Tuple::Codec, make_format_string (& s.info));
-    tuple.set_str (Tuple::Quality, str_printf ("%s, %d Hz", (s.channels == 2) ?
-     _("Stereo") : (s.channels > 2) ? _("Surround") : _("Mono"), (int) s.rate));
+    tuple.set_str (Tuple::Quality, str_printf ("%s, %d Hz, %s", (s.channels == 2) ?
+     _("Stereo") : (s.channels > 2) ? _("Surround") : _("Mono"), (int) s.rate, (s.info.vbr == MPG123_CBR) ? "CBR" : s.info.vbr == MPG123_VBR ? "VBR" : "ABR"));
     tuple.set_int (Tuple::Bitrate, s.info.bitrate);
 
     if (! stream)

--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -263,7 +263,8 @@ static bool read_mpg123_info (const char * filename, VFSFile & file, Tuple & tup
         if (length > 0)
         {
             tuple.set_int (Tuple::Length, length);
-            tuple.set_int (Tuple::Bitrate, 8 * size / length);
+            if (s.info.vbr == MPG123_CBR) tuple.set_int (Tuple::Bitrate, s.info.bitrate);
+            else tuple.set_int (Tuple::Bitrate, 8 * size / length);
         }
     }
 


### PR DESCRIPTION
When the bitrate is CBR a wrong value was showed in song info and in the playlist because it was calculated. Now when the bitrate is CBR the bitrate is obtained from the first frame of libmpg123.

Also now in info is shown if file is CBR, VBR or ABR.

https://redmine.audacious-media-player.org/issues/937