### PR TITLE
qtui: Use doubleClicked signal instead of activate

### DIFF
--- a/src/qtui/playlist-qt.cc
+++ b/src/qtui/playlist-qt.cc
@@ -34,22 +34,6 @@
 
 #include "../ui-common/menu-ops.h"
 
-/* Suppress single-click activation on platforms which provide it (KDE). */
-class PlaylistStyle : public QProxyStyle
-{
-public:
-    int styleHint(StyleHint hint,
-                  const QStyleOption * option = nullptr,
-                  const QWidget * widget = nullptr,
-                  QStyleHintReturn * returnData = nullptr) const override
-    {
-        if (hint == QStyle::SH_ItemView_ActivateItemOnSingleClick)
-            return 0;
-
-        return QProxyStyle::styleHint(hint, option, widget, returnData);
-    }
-};
-
 PlaylistWidget::PlaylistWidget(QWidget * parent, Playlist playlist)
     : audqt::TreeView(parent), m_playlist(playlist),
       model(new PlaylistModel(this, playlist)),
@@ -75,7 +59,8 @@ PlaylistWidget::PlaylistWidget(QWidget * parent, Playlist playlist)
     setSelectionMode(ExtendedSelection);
     setDragDropMode(DragDrop);
     setMouseTracking(true);
-    setStyle(new PlaylistStyle);
+
+    connect(this, &QTreeView::doubleClicked, this, &PlaylistWidget::doubleClick);
 
     updateSettings();
     header->updateColumns();
@@ -133,7 +118,7 @@ QModelIndex PlaylistWidget::visibleIndexNear(int row)
     return index;
 }
 
-void PlaylistWidget::activate(const QModelIndex & index)
+void PlaylistWidget::doubleClick(const QModelIndex & index)
 {
     if (index.isValid())
     {

--- a/src/qtui/playlist-qt.h
+++ b/src/qtui/playlist-qt.h
@@ -69,7 +69,7 @@ private:
                            QItemSelection & deselected);
     void updateSelection(int rowsBefore, int rowsAfter);
 
-    void activate(const QModelIndex & index);
+    void doubleClick(const QModelIndex & index);
     void contextMenuEvent(QContextMenuEvent * event);
     void keyPressEvent(QKeyEvent * event);
     void mouseMoveEvent(QMouseEvent * event);


### PR DESCRIPTION
This ensures that playback will only occur when a playlist item is double-
clicked, regardless of the user's desktop single-click setting.