### PR TITLE
notify: Allow specifying a custom notification duration

### DIFF
--- a/src/notify/notify.cc
+++ b/src/notify/notify.cc
@@ -72,6 +72,8 @@ const char * const NotifyPlugin::defaults[] = {
  "actions", "TRUE",
  "resident", "FALSE",
  "album", "TRUE",
+ "custom_duration_enabled", "FALSE",
+ "custom_duration", "1",
  nullptr
 };
 
@@ -104,7 +106,11 @@ const PreferencesWidget NotifyPlugin::widgets[] = {
     WidgetCheck (N_("Always show notification"),
         WidgetBool ("notify", "resident", reinit)),
     WidgetCheck (N_("Include album name in notification"),
-        WidgetBool ("notify", "album", reinit))
+        WidgetBool ("notify", "album", reinit)),
+    WidgetCheck (N_("Custom notification duration"),
+        WidgetBool ("notify", "custom_duration_enabled", reinit)),
+    WidgetSpin (N_("Duration :"),
+        WidgetInt ("notify", "custom_duration", reinit), {1, 100, 1, N_("seconds")}, WIDGET_CHILD)
 };
 
 const PluginPreferences NotifyPlugin::prefs = {{widgets}};

--- a/src/notify/osd.cc
+++ b/src/notify/osd.cc
@@ -33,6 +33,22 @@ static void show_cb ()
     aud_ui_show (true);
 }
 
+static int get_notification_timeout (bool resident)
+{
+    if (resident)
+    {
+        return NOTIFY_EXPIRES_NEVER;
+    }
+    else if (aud_get_bool("notify", "custom_duration_enabled"))
+    {
+        return aud_get_int("notify", "custom_duration") * 1000;
+    }
+    else
+    {
+        return NOTIFY_EXPIRES_DEFAULT;
+    }
+}
+
 static void osd_setup (NotifyNotification *notification)
 {
     bool resident = aud_get_bool ("notify", "resident");
@@ -45,8 +61,7 @@ static void osd_setup (NotifyNotification *notification)
     notify_notification_set_hint (notification, "transient", g_variant_new_boolean (! resident));
 
     notify_notification_set_urgency (notification, NOTIFY_URGENCY_LOW);
-    notify_notification_set_timeout (notification, resident ?
-     NOTIFY_EXPIRES_NEVER : NOTIFY_EXPIRES_DEFAULT);
+    notify_notification_set_timeout (notification, get_notification_timeout (resident));
 }
 
 void osd_setup_buttons (NotifyNotification *notification)


### PR DESCRIPTION
The notifications seemed too long for me, and I don't want to change the default setting in the server since sometimes other applications might display more text in there and a longer duration might bew thus necessary to read them. This allows the user to specify their own duration if desired.
The only caveat is that checking both "Always show notification" and "Custom notification duration" will result in the notification always being shown due to how the code is structured, as I can't find a way to uncheck one of the CheckBoxes if the other is already checked. Suggestions welcome.