### PR TITLE
qtui: Implement wheelEvent for TimeSlider

### DIFF
--- a/src/qtui/time_slider.cc
+++ b/src/qtui/time_slider.cc
@@ -96,6 +96,19 @@ TimeSlider::TimeSlider(QWidget * parent)
     start_stop();
 }
 
+void TimeSlider::wheelEvent(QWheelEvent *event)
+{
+    m_scroll_delta += event->angleDelta().y();
+
+    /* we want discrete steps here */
+    int steps = m_scroll_delta / 120;
+    if (steps != 0)
+    {
+        m_scroll_delta -= 120 * steps;
+        aud_drct_seek(aud_drct_get_time() + steps * aud_get_int("step_size") * 1000);
+    }
+}
+
 void TimeSlider::set_label(int time, int length)
 {
     QString text;

--- a/src/qtui/time_slider.h
+++ b/src/qtui/time_slider.h
@@ -44,6 +44,9 @@ public:
 
     TimeSliderLabel * label() { return m_label; }
 
+protected:
+    void wheelEvent(QWheelEvent *event);
+
 private:
     void set_label(int time, int length);
 
@@ -54,6 +57,8 @@ private:
     void released();
 
     TimeSliderLabel * m_label;
+
+    int m_scroll_delta = 0;
 
     const Timer<TimeSlider> m_timer{TimerRate::Hz4, this, &TimeSlider::update};
 


### PR DESCRIPTION
Allows seeking with the mouse wheel by placing the cursor over the
TimeSlider. This feature is already available in GTK mode.