### PR TITLE
Move from freedb.org to gnudb.gnudb.org

### DIFF
--- a/src/cdaudio/cdaudio-ng.cc
+++ b/src/cdaudio/cdaudio-ng.cc
@@ -126,7 +126,7 @@ const char * const CDAudio::defaults[] = {
  "use_cdtext", "TRUE",
  "use_cddb", "TRUE",
  "cddbhttp", "FALSE",
- "cddbserver", "freedb.org",
+ "cddbserver", "gnudb.gnudb.org",
  "cddbport", "8880",
  nullptr};
 


### PR DESCRIPTION
The freedb.org database of compact track listings has shut down. Any
program functionality that tries to fetch from or submit data to
freedb.org is broken now.

An alternative service is available at gnudb.gnudb.org, see
https://www.gnudb.org/

Fixes https://redmine.audacious-media-player.org/issues/994