### PR TITLE
Implement album artist support in scrobbler2 plugin

### DIFF
--- a/src/scrobbler2/scrobbler.cc
+++ b/src/scrobbler2/scrobbler.cc
@@ -94,6 +94,7 @@ static gboolean queue_track_to_scrobble (void * data) {
     StringBuf artist = clean_string (playing_track.get_str (Tuple::Artist));
     StringBuf title  = clean_string (playing_track.get_str (Tuple::Title));
     StringBuf album  = clean_string (playing_track.get_str (Tuple::Album));
+    StringBuf album_artist = clean_string (playing_track.get_str (Tuple::AlbumArtist));
 
     int track  = playing_track.get_int (Tuple::Track);
     int length = playing_track.get_int (Tuple::Length);
@@ -111,9 +112,10 @@ static gboolean queue_track_to_scrobble (void * data) {
             //This isn't exactly the scrobbler.log format because the header
             //is missing, but we're sticking to it anyway...
             //See http://www.audioscrobbler.net/wiki/Portable_Player_Logging
-            if (fprintf(f, "%s\t%s\t%s\t%s\t%i\tL\t%" G_GINT64_FORMAT "\n",
+            if (fprintf(f, "%s\t%s\t%s\t%s\t%i\tL\t%" G_GINT64_FORMAT "\t%s\n",
              (const char *)artist, (const char *)album, (const char *)title,
-             (const char *)track_str, length / 1000, timestamp) < 0) {
+             (const char *)track_str, length / 1000, timestamp,
+             (const char *)album_artist ) < 0) {
                 perror("fprintf");
             } else {
                 pthread_mutex_lock(&communication_mutex);


### PR DESCRIPTION
The purpose of this PR is to add album artist support to `scrobbler2` plugin, with some additional fixes in functions used for handling scrobble cache file.

The first commit fixes two problems which can happen when the scrobble cache file (`scrobbler.log`) is parsed. In some cases reading incorrectly formatted fields in `scrobbler.log` can cause a segmentation fault (a minimal example is a field containing only three `\t` characters). The other problem is that reading an empty line from scrobble cache stops further cache processing, and causes all subsequent cache entries to be lost. 

This doesn't seem to be a problem in real life usage, because the plugin never creates incorrectly formatted cache entries. I only found these problems when I was feeding various incorrectly formatted cache files to the plugin while testing my changes. But IMO this is something that should be fixed anyway. And having a dedicated function for validating format made further work easier.

The second commit implements album artist support in the plugin. Album artist info is read from the metadata of media file, and is sent to Last.fm in `track.updateNowPlaying` and `track.scrobble` API method calls. Scrobble cache file format is changed to store an additional field, but the change is implemented so that it's backward-compatible (`scrobbler.log` created by previous plugin version  will still be parsed correctly).