### PR TITLE
Enable the menu item to Jump to a Song in QT5

### DIFF
--- a/src/skins-qt/menus.cc
+++ b/src/skins-qt/menus.cc
@@ -107,9 +107,9 @@ static const audqt::MenuItem playback_items[] = {
     audqt::MenuSep (),
     audqt::MenuCommand ({N_("Set A-B Repeat"), nullptr, "A"}, action_ab_set),
     audqt::MenuCommand ({N_("Clear A-B Repeat"), nullptr, "Shift+A"}, action_ab_clear),
-#if 0
     audqt::MenuSep (),
-    audqt::MenuCommand ({N_("Jump to Song ..."), "go-jump", "J"}, audgui_jump_to_track),
+    audqt::MenuCommand ({N_("Jump to Song ..."), "go-jump", "J"}, aud_ui_show_jump_to_song),
+#if 0
     audqt::MenuCommand ({N_("Jump to Time ..."), "go-jump", "Ctrl+J"}, audgui_jump_to_time)
 #endif
 };


### PR DESCRIPTION
This is a companion to https://github.com/audacious-media-player/audacious/pull/42 and dependent upon it