### PR TITLE
Fix bitrate unit formatting

### DIFF
--- a/src/filewriter/filewriter.cc
+++ b/src/filewriter/filewriter.cc
@@ -427,22 +427,22 @@ static const ComboItem mp3_sample_rates[] = {
 };
 
 static const ComboItem mp3_bitrates[] = {
-    ComboItem(N_("8 kbps"), 8),
-    ComboItem(N_("16 kbps"), 16),
-    ComboItem(N_("32 kbps"), 32),
-    ComboItem(N_("40 kbps"), 40),
-    ComboItem(N_("48 kbps"), 48),
-    ComboItem(N_("56 kbps"), 56),
-    ComboItem(N_("64 kbps"), 64),
-    ComboItem(N_("80 kbps"), 80),
-    ComboItem(N_("96 kbps"), 96),
-    ComboItem(N_("112 kbps"), 112),
-    ComboItem(N_("128 kbps"), 128),
-    ComboItem(N_("160 kbps"), 160),
-    ComboItem(N_("192 kbps"), 192),
-    ComboItem(N_("224 kbps"), 224),
-    ComboItem(N_("256 kbps"), 256),
-    ComboItem(N_("320 kbps"), 320)
+    ComboItem(N_("8 kbit/s"), 8),
+    ComboItem(N_("16 kbit/s"), 16),
+    ComboItem(N_("32 kbit/s"), 32),
+    ComboItem(N_("40 kbit/s"), 40),
+    ComboItem(N_("48 kbit/s"), 48),
+    ComboItem(N_("56 kbit/s"), 56),
+    ComboItem(N_("64 kbit/s"), 64),
+    ComboItem(N_("80 kbit/s"), 80),
+    ComboItem(N_("96 kbit/s"), 96),
+    ComboItem(N_("112 kbit/s"), 112),
+    ComboItem(N_("128 kbit/s"), 128),
+    ComboItem(N_("160 kbit/s"), 160),
+    ComboItem(N_("192 kbit/s"), 192),
+    ComboItem(N_("224 kbit/s"), 224),
+    ComboItem(N_("256 kbit/s"), 256),
+    ComboItem(N_("320 kbit/s"), 320)
 };
 
 static const ComboItem mp3_modes[] = {

--- a/src/gtkui/ui_statusbar.cc
+++ b/src/gtkui/ui_statusbar.cc
@@ -78,7 +78,7 @@ static void ui_statusbar_info_change (void *, void * label)
     }
 
     if (bitrate > 0)
-        str_append_printf (buf, _("%d kbps"), bitrate / 1000);
+        str_append_printf (buf, _("%d kbit/s"), bitrate / 1000);
 
     gtk_label_set_text ((GtkLabel *) label, buf);
 }

--- a/src/moonstone/playlist_model.cc
+++ b/src/moonstone/playlist_model.cc
@@ -123,7 +123,7 @@ QVariant PlaylistModel::data(const QModelIndex & index, int role) const
         case Length:
             return QString(str_format_time(val));
         case Bitrate:
-            return QString("%1 kbps").arg(val);
+            return QString("%1 kbit/s").arg(val);
         default:
             return QString("%1").arg(val);
         }

--- a/src/qtui/playlist_model.cc
+++ b/src/qtui/playlist_model.cc
@@ -124,7 +124,7 @@ QVariant PlaylistModel::data(const QModelIndex & index, int role) const
         case Length:
             return QString(str_format_time(val));
         case Bitrate:
-            return QString("%1 kbps").arg(val);
+            return QString("%1 kbit/s").arg(val);
         default:
             return QString("%1").arg(val);
         }

--- a/src/qtui/status_bar.cc
+++ b/src/qtui/status_bar.cc
@@ -171,7 +171,7 @@ void StatusBar::update_codec()
     }
 
     if (bitrate > 0)
-        str_append_printf(buf, _("%d kbps"), bitrate / 1000);
+        str_append_printf(buf, _("%d kbit/s"), bitrate / 1000);
 
     codec_label->setText((const char *)buf);
     codec_label->show();

--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -329,7 +329,7 @@ static void mainwin_set_song_info (int bitrate, int samplerate, int channels)
     mainwin_monostereo->set_num_channels (channels);
 
     if (bitrate > 0)
-        snprintf (scratch, sizeof scratch, "%d kbps", bitrate / 1000);
+        snprintf (scratch, sizeof scratch, "%d kbit/s", bitrate / 1000);
     else
         scratch[0] = 0;
 

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -345,7 +345,7 @@ static void mainwin_set_song_info (int bitrate, int samplerate, int channels)
     mainwin_monostereo->set_num_channels (channels);
 
     if (bitrate > 0)
-        snprintf (scratch, sizeof scratch, "%d kbps", bitrate / 1000);
+        snprintf (scratch, sizeof scratch, "%d kbit/s", bitrate / 1000);
     else
         scratch[0] = 0;
 


### PR DESCRIPTION
This commit updates the unit formatting for bitrates to the universal
symbol from the now deprecated abbreviation.