### PR TITLE
xsf: Fix compiler warnings

### DIFF
--- a/src/xsf/XSFFile.cc
+++ b/src/xsf/XSFFile.cc
@@ -48,32 +48,14 @@ static inline void Set32BitsLE(uint32_t input, uint8_t *output)
 	output[3] = (input >> 24) & 0xFF;
 }
 
-// The whitespace trimming was modified from the following answer on Stack Overflow:
-// http://stackoverflow.com/a/217605
+// The whitespace trimming is from the following answer on Stack Overflow:
+// https://stackoverflow.com/a/17976541
 
-struct IsWhitespace : std::unary_function<char, bool>
+static inline std::string TrimWhitespace(const std::string &s)
 {
-	bool operator()(const char &x) const
-	{
-		return x >= 0x01 && x <= 0x20;
-	}
-};
-
-static inline std::string LeftTrimWhitespace(const std::string &orig)
-{
-	auto first_non_space = std::find_if(orig.begin(), orig.end(), std::not1(IsWhitespace()));
-	return std::string(first_non_space, orig.end());
-}
-
-static inline std::string RightTrimWhitespace(const std::string &orig)
-{
-	auto last_non_space = std::find_if(orig.rbegin(), orig.rend(), std::not1(IsWhitespace())).base();
-	return std::string(orig.begin(), last_non_space);
-}
-
-static inline std::string TrimWhitespace(const std::string &orig)
-{
-	return LeftTrimWhitespace(RightTrimWhitespace(orig));
+	auto wsfront = std::find_if_not(s.begin(), s.end(), [](int c) { return std::isspace(c); });
+	auto wsback = std::find_if_not(s.rbegin(), s.rend(), [](int c) { return std::isspace(c); }).base();
+	return (wsback <= wsfront ? std::string() : std::string(wsfront, wsback));
 }
 
 XSFFile::XSFFile() : xSFType(0), hasFile(false), rawData(), reservedSection(), programSection(), tags()


### PR DESCRIPTION
This fixes the following deprecation warnings.

@jlindgren90: Could you please check if this compiles with older compilers? I think we still support GCC 4.7, right? Thanks.

```
../src/xsf/XSFFile.cc:54:28: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
   54 | struct IsWhitespace : std::unary_function<char, bool>
      |                            ^~~~~~~~~~~~~~
In file included from /usr/include/c++/12.1.0/functional:49,
                 from ../src/xsf/XSFFile.cc:36:
/usr/include/c++/12.1.0/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
../src/xsf/XSFFile.cc: In function 'std::string LeftTrimWhitespace(const std::string&)':
../src/xsf/XSFFile.cc:64:80: warning: 'constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = IsWhitespace]' is deprecated: use 'std::not_fn' instead [-Wdeprecated-declarations]
   64 |         auto first_non_space = std::find_if(orig.begin(), orig.end(), std::not1(IsWhitespace()));
      |                                                                       ~~~~~~~~~^~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/bits/stl_function.h:1046:5: note: declared here
 1046 |     not1(const _Predicate& __pred)
      |     ^~~~
../src/xsf/XSFFile.cc: In function 'std::string RightTrimWhitespace(const std::string&)':
../src/xsf/XSFFile.cc:70:81: warning: 'constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = IsWhitespace]' is deprecated: use 'std::not_fn' instead [-Wdeprecated-declarations]
   70 |         auto last_non_space = std::find_if(orig.rbegin(), orig.rend(), std::not1(IsWhitespace())).base();
      |                                                                        ~~~~~~~~~^~~~~~~~~~~~~~~~
/usr/include/c++/12.1.0/bits/stl_function.h:1046:5: note: declared here
 1046 |     not1(const _Predicate& __pred)
      |     ^~~~
```

