### PR TITLE
Add publisher and catalog number (qtui, gtkui, flac, vorbis)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ dnl ***
 dnl Initialize
 dnl ==========
 AC_PREREQ([2.59])
-AC_INIT([audacious-plugins], [4.2])
+AC_INIT([audacious-plugins], [4.3-devel])
 AC_COPYRIGHT([Copyright (C) 2001-2022 Audacious developers and others])
 
 AC_DEFINE_UNQUOTED([PACKAGE], "$PACKAGE_NAME", [Name of package])
@@ -33,9 +33,9 @@ LIBS="$LIBS $LIBINTL"
 dnl Check for Audacious
 dnl ===================
 
-PKG_CHECK_MODULES(AUDACIOUS, [audacious >= 4.2],
+PKG_CHECK_MODULES(AUDACIOUS, [audacious >= 4.3],
     [],
-    [AC_MSG_ERROR([Cannot find Audacious 4.2; have you installed Audacious yet?])]
+    [AC_MSG_ERROR([Cannot find Audacious 4.3; have you installed Audacious yet?])]
 )
 
 CPPFLAGS="$CPPFLAGS $AUDACIOUS_CFLAGS"

--- a/src/flac/metadata.cc
+++ b/src/flac/metadata.cc
@@ -179,6 +179,9 @@ bool FLACng::write_tuple(const char *filename, VFSFile &file, const Tuple &tuple
     insert_int_tuple_to_vc(vc_block, tuple, Tuple::Year, "DATE");
     insert_int_tuple_to_vc(vc_block, tuple, Tuple::Track, "TRACKNUMBER");
 
+    insert_str_tuple_to_vc(vc_block, tuple, Tuple::Publisher, "publisher");
+    insert_str_tuple_to_vc(vc_block, tuple, Tuple::CatalogNum, "CATALOGNUMBER");
+
     FLAC__metadata_iterator_insert_block_after(iter, vc_block);
 
     FLAC__metadata_iterator_delete(iter);
@@ -239,6 +242,8 @@ static void parse_comment (Tuple & tuple, const char * key, const char * value)
         {"GENRE", Tuple::Genre},
         {"DESCRIPTION", Tuple::Description},
         {"musicbrainz_trackid", Tuple::MusicBrainzID},
+        {"publisher", Tuple::Publisher},
+        {"CATALOGNUMBER", Tuple::CatalogNum},
     };
 
     for (auto & tfield : tfields)

--- a/src/gtkui/columns.cc
+++ b/src/gtkui/columns.cc
@@ -46,7 +46,9 @@ const char * const pw_col_names[PW_COLS] = {
     N_("File name"),
     N_("Custom title"),
     N_("Bitrate"),
-    N_("Comment")
+    N_("Comment"),
+    N_("Publisher"),
+    N_("Catalog number")
 };
 
 int pw_num_cols;
@@ -68,7 +70,9 @@ static const char * const pw_col_keys[PW_COLS] = {
     "filename",
     "custom",
     "bitrate",
-    "comment"
+    "comment",
+    "publisher",
+    "catalog-number"
 };
 
 static const int pw_default_widths[PW_COLS] = {
@@ -86,7 +90,9 @@ static const int pw_default_widths[PW_COLS] = {
     275,  // filename
     275,  // custom title
     10,   // bitrate
-    275   // comment
+    275,  // comment
+    175,  // publisher
+    75   // catalog number
 };
 
 void pw_col_init ()

--- a/src/gtkui/ui_playlist_widget.cc
+++ b/src/gtkui/ui_playlist_widget.cc
@@ -50,7 +50,9 @@ static const GType pw_col_types[PW_COLS] =
     G_TYPE_STRING,  // file name
     G_TYPE_STRING,  // custom title
     G_TYPE_STRING,  // bitrate
-    G_TYPE_STRING   // comment
+    G_TYPE_STRING,  // comment
+    G_TYPE_STRING,  // publisher
+    G_TYPE_STRING   // catalog number
 };
 
 static const int pw_col_min_widths[PW_COLS] = {
@@ -68,7 +70,9 @@ static const int pw_col_min_widths[PW_COLS] = {
     10,  // file name
     10,  // custom title
     3,   // bitrate
-    10   // comment
+    10,  // comment,
+    10,  // publisher
+    3    // catalog number
 };
 
 static const bool pw_col_label[PW_COLS] = {
@@ -86,7 +90,9 @@ static const bool pw_col_label[PW_COLS] = {
     true,   // file name
     true,   // custom title
     false,  // bitrate
-    true    // comment
+    true,   // comment
+    false,  // publisher
+    false   // catalog number
 };
 
 static const Playlist::SortType pw_col_sort_types[PW_COLS] = {
@@ -104,7 +110,9 @@ static const Playlist::SortType pw_col_sort_types[PW_COLS] = {
     Playlist::Filename,        // file name
     Playlist::FormattedTitle,  // custom title
     Playlist::n_sort_types,    // bitrate
-    Playlist::Comment          // comment
+    Playlist::Comment,         // comment
+    Playlist::Publisher,       // publisher
+    Playlist::CatalogNum       // catalog number
 };
 
 struct PlaylistWidgetData
@@ -208,6 +216,12 @@ static void get_value (void * user, int row, int column, GValue * value)
         break;
     case PW_COL_COMMENT:
         set_string_from_tuple (value, tuple, Tuple::Comment);
+        break;
+    case PW_COL_PUBLISHER:
+        set_string_from_tuple (value, tuple, Tuple::Publisher);
+        break;
+    case PW_COL_CATALOG_NUM:
+        set_string_from_tuple (value, tuple, Tuple::CatalogNum);
         break;
     }
 }

--- a/src/gtkui/ui_playlist_widget.h
+++ b/src/gtkui/ui_playlist_widget.h
@@ -43,6 +43,8 @@ enum {
     PW_COL_CUSTOM,
     PW_COL_BITRATE,
     PW_COL_COMMENT,
+    PW_COL_PUBLISHER,
+    PW_COL_CATALOG_NUM,
     PW_COLS
 };
 

--- a/src/qtui/playlist_header.cc
+++ b/src/qtui/playlist_header.cc
@@ -37,7 +37,8 @@
 static const char * const s_col_keys[] = {
     "number",       "title",    "artist", "year",    "album",
     "album-artist", "track",    "genre",  "queued",  "length",
-    "path",         "filename", "custom", "bitrate", "comment"};
+    "path",         "filename", "custom", "bitrate", "comment",
+    "publisher",    "catalog-number"};
 
 static const int s_default_widths[] = {
     25,  // entry number
@@ -54,7 +55,9 @@ static const int s_default_widths[] = {
     275, // filename
     275, // custom title
     75,  // bitrate
-    275  // comment
+    275, // comment
+    175, // publisher
+    75   // catalog number
 };
 
 static const Playlist::SortType s_sort_types[] = {
@@ -72,7 +75,9 @@ static const Playlist::SortType s_sort_types[] = {
     Playlist::Filename,       // file name
     Playlist::FormattedTitle, // custom title
     Playlist::n_sort_types,   // bitrate
-    Playlist::Comment         // comment
+    Playlist::Comment,        // comment,
+    Playlist::Publisher,      // publisher
+    Playlist::CatalogNum      // catalog number
 };
 
 static_assert(aud::n_elems(s_col_keys) == PlaylistModel::n_cols,

--- a/src/qtui/playlist_model.cc
+++ b/src/qtui/playlist_model.cc
@@ -33,13 +33,15 @@ const char * const PlaylistModel::labels[] = {
     N_("Entry Number"),   N_("Title"),        N_("Artist"),    N_("Year"),
     N_("Album"),          N_("Album Artist"), N_("Track"),     N_("Genre"),
     N_("Queue Position"), N_("Length"),       N_("File Path"), N_("File Name"),
-    N_("Custom Title"),   N_("Bitrate"),      N_("Comment")};
+    N_("Custom Title"),   N_("Bitrate"),      N_("Comment"), N_("Publisher"),
+    N_("Catalog Number")};
 
 static const Tuple::Field s_fields[] = {
     Tuple::Invalid,        Tuple::Title,       Tuple::Artist, Tuple::Year,
     Tuple::Album,          Tuple::AlbumArtist, Tuple::Track,  Tuple::Genre,
     Tuple::Invalid,        Tuple::Length,      Tuple::Path,   Tuple::Basename,
-    Tuple::FormattedTitle, Tuple::Bitrate,     Tuple::Comment};
+    Tuple::FormattedTitle, Tuple::Bitrate,     Tuple::Comment, Tuple::Publisher,
+    Tuple::CatalogNum};
 
 static_assert(aud::n_elems(PlaylistModel::labels) == PlaylistModel::n_cols,
               "update PlaylistModel::labels");
@@ -186,6 +188,8 @@ QVariant PlaylistModel::headerData(int section, Qt::Orientation orientation,
             return QString(_("Q#"));
         case Track:
             return QString(_("T#"));
+        case CatalogNum:
+            return QString(_("C#"));
         }
 
         return QString(_(labels[col]));

--- a/src/qtui/playlist_model.h
+++ b/src/qtui/playlist_model.h
@@ -45,6 +45,8 @@ public:
         CustomTitle,
         Bitrate,
         Comment,
+        Publisher,
+        CatalogNum,
         n_cols
     };
 

--- a/src/vorbis/vcupdate.cc
+++ b/src/vorbis/vcupdate.cc
@@ -105,6 +105,9 @@ bool VorbisPlugin::write_tuple (const char * filename, VFSFile & file, const Tup
     insert_int_tuple_field_to_dictionary (tuple, Tuple::Year, dict, "DATE");
     insert_int_tuple_field_to_dictionary (tuple, Tuple::Track, dict, "TRACKNUMBER");
 
+    insert_str_tuple_field_to_dictionary (tuple, Tuple::Publisher, dict, "publisher");
+    insert_str_tuple_field_to_dictionary (tuple, Tuple::CatalogNum, dict, "CATALOGNUMBER");
+
     dictionary_to_vorbis_comment (& edit.vc, dict);
 
     auto temp_vfs = VFSFile::tmpfile ();

--- a/src/vorbis/vorbis.cc
+++ b/src/vorbis/vorbis.cc
@@ -144,6 +144,8 @@ static void read_comment (vorbis_comment * comment, Tuple & tuple)
     set_tuple_str (tuple, Tuple::Comment, comment, "COMMENT");
     set_tuple_str (tuple, Tuple::Description, comment, "DESCRIPTION");
     set_tuple_str (tuple, Tuple::MusicBrainzID, comment, "musicbrainz_trackid");
+    set_tuple_str (tuple, Tuple::Publisher, comment, "publisher");
+    set_tuple_str (tuple, Tuple::CatalogNum, comment, "CATALOGNUMBER");
 
     if ((tmps = vorbis_comment_query (comment, "TRACKNUMBER", 0)))
         tuple.set_int (Tuple::Track, atoi (tmps));


### PR DESCRIPTION
Requires audacious-media-player/audacious#53. Adds publisher and catalog number support to qtui, gtkui, flac, and vorbis.