### PR TITLE
oss: Cleanup header handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,7 +357,7 @@ test_oss4 () {
     OLD_CPPFLAGS="$CPPFLAGS"
     CPPFLAGS="$CPPFLAGS $OSS_CFLAGS"
     have_oss4=no
-    AC_CHECK_HEADERS(sys/soundcard.h soundcard.h, [
+    AC_CHECK_HEADERS(sys/soundcard.h, [
         have_oss4=yes
         break
     ])

--- a/src/config.h.meson
+++ b/src/config.h.meson
@@ -32,5 +32,3 @@
 #mesondefine HAVE_ADPLUG_NEMUOPL_H
 #mesondefine HAVE_ADPLUG_WEMUOPL_H
 #mesondefine HAVE_ADPLUG_KEMUOPL_H
-
-#mesondefine HAVE_SYS_SOUNDCARD_H

--- a/src/oss4/meson.build
+++ b/src/oss4/meson.build
@@ -12,9 +12,6 @@ oss_sources = [
 
 if cxx.has_header('sys/soundcard.h', args: '-I' + oss_inc)
   have_oss4 = true
-  conf.set10('HAVE_SYS_SOUNDCARD_H', true)
-elif cxx.has_header('soundcard.h', args: '-I' + oss_inc)
-  have_oss4 = true
 else
   have_oss4 = false
 endif

--- a/src/oss4/oss.h
+++ b/src/oss4/oss.h
@@ -26,12 +26,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/ioctl.h>
-
-#ifdef HAVE_SYS_SOUNDCARD_H
 #include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
 
 #include <libaudcore/i18n.h>
 #include <libaudcore/plugin.h>


### PR DESCRIPTION
OpenBSD has not used OSS for ages so stop checking for the soundcard.h header outside of sys/.