### PR TITLE
Select text already in SearchBar

### DIFF
--- a/src/qtui/search_bar.cc
+++ b/src/qtui/search_bar.cc
@@ -103,3 +103,13 @@ void SearchBar::keyPressEvent(QKeyEvent * event)
 
     QWidget::keyPressEvent(event);
 }
+
+void SearchBar::setFocus()
+{
+	QWidget::setFocus();
+	if (m_entry->text().length() > 0)
+	{
+		m_entry->selectAll();
+	}
+}
+

--- a/src/qtui/search_bar.h
+++ b/src/qtui/search_bar.h
@@ -29,6 +29,7 @@ class SearchBar : public QWidget
 {
 public:
     SearchBar(QWidget * parent, PlaylistWidget * playlistWidget);
+    void setFocus();
 
 private:
     void keyPressEvent(QKeyEvent * event);


### PR DESCRIPTION
If there is text in SearchBar, select it when the user presses ctrl+f.
If you use the mouse pointer you can still set the cursor where you want, without having to click twice.