### PR TITLE
Use embedded lyrics from ID3 TAG

### DIFF
--- a/src/lyricwiki-qt/lyricwiki.cc
+++ b/src/lyricwiki-qt/lyricwiki.cc
@@ -500,15 +500,15 @@ static void lyricwiki_playback_began ()
 
     if (aud_get_bool ("lyricwiki", "use-embedded"))
     {
-      String embedded_lyrics = tuple.get_str (Tuple::Lyrics);
-      if (embedded_lyrics && embedded_lyrics[0])
-      {
-        g_state.lyrics = embedded_lyrics;
-        g_state.source = LyricsState::Source::Embedded;
-        g_state.error = false;
-        update_lyrics_window(g_state.title, g_state.artist, g_state.lyrics);
-        return;
-      }
+        String embedded_lyrics = tuple.get_str (Tuple::Lyrics);
+        if (embedded_lyrics && embedded_lyrics[0])
+        {
+            g_state.lyrics = embedded_lyrics;
+            g_state.source = LyricsState::Source::Embedded;
+            g_state.error = false;
+            update_lyrics_window (g_state.title, g_state.artist, g_state.lyrics);
+            return;
+        }
     }
 
     if (! aud_get_bool ("lyricwiki", "enable-file-provider") || ! file_provider.match (g_state))
@@ -528,7 +528,7 @@ static void lyricwiki_playback_began ()
     }
 
     // No lyrics source - set default state
-    update_lyrics_window_notfound(g_state);
+    update_lyrics_window_notfound (g_state);
 }
 
 static void lw_cleanup (QObject * object = nullptr)

--- a/src/lyricwiki-qt/lyricwiki.cc
+++ b/src/lyricwiki-qt/lyricwiki.cc
@@ -467,20 +467,6 @@ static void lyricwiki_playback_began ()
     g_state.title = tuple.get_str (Tuple::Title);
     g_state.artist = tuple.get_str (Tuple::Artist);
 
-    update_lyrics_window_notfound(g_state); // Set default state
-    if (aud_get_bool ("lyricwiki", "use-embedded"))
-    {
-      String embedded_lyrics = tuple.get_str (Tuple::Lyrics);
-      if (embedded_lyrics && embedded_lyrics[0])
-      {
-        g_state.lyrics = embedded_lyrics;
-        g_state.source = LyricsState::Source::Embedded;
-        g_state.error = false;
-        update_lyrics_window(g_state.title, g_state.artist, g_state.lyrics);
-        return;
-      }
-    }
-
     if (aud_get_bool ("lyricwiki", "split-title-on-chars"))
     {
         QString artist = QString (g_state.artist);
@@ -512,6 +498,19 @@ static void lyricwiki_playback_began ()
         }
     }
 
+    if (aud_get_bool ("lyricwiki", "use-embedded"))
+    {
+      String embedded_lyrics = tuple.get_str (Tuple::Lyrics);
+      if (embedded_lyrics && embedded_lyrics[0])
+      {
+        g_state.lyrics = embedded_lyrics;
+        g_state.source = LyricsState::Source::Embedded;
+        g_state.error = false;
+        update_lyrics_window(g_state.title, g_state.artist, g_state.lyrics);
+        return;
+      }
+    }
+
     if (! aud_get_bool ("lyricwiki", "enable-file-provider") || ! file_provider.match (g_state))
     {
         if (! g_state.artist || ! g_state.title)
@@ -522,8 +521,14 @@ static void lyricwiki_playback_began ()
 
         auto rsrc = remote_source ();
         if (rsrc)
-            rsrc->match (g_state);
+        {
+          rsrc->match (g_state);
+          return;
+        }
     }
+
+    // No lyrics source - set default state
+    update_lyrics_window_notfound(g_state);
 }
 
 static void lw_cleanup (QObject * object = nullptr)


### PR DESCRIPTION
Why not to get Lyrics tag display support? I ported Fauxdacious lyricwiki plugin to display lyrics. There is my another another commit in the audacious core project, where I made the lyrics tag support.
Please, check this out.
Thank You!