### PR TITLE
Fix Qt 6 deprecation warnings with a compatibility layer

### DIFF
--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -22,7 +22,7 @@ ubuntu_packages='gettext libadplug-dev libasound2-dev libavformat-dev
                  libjack-jackd2-dev liblircclient-dev libmms-dev libmodplug-dev
                  libmp3lame-dev libmpg123-dev libneon27-gnutls-dev libnotify-dev
                  libopenmpt-dev libopusfile-dev libpulse-dev libqt5opengl5-dev
-                 libqt5x11extras5-dev libsamplerate0-dev libsdl1.2-dev
+                 libqt5x11extras5-dev libsamplerate0-dev libsdl2-dev
                  libsidplayfp-dev libsndfile1-dev libsndio-dev libsoxr-dev
                  libvorbis-dev libwavpack-dev libxml2-dev qtbase5-dev
                  qtmultimedia5-dev'

--- a/src/oss4/oss.cc
+++ b/src/oss4/oss.cc
@@ -118,7 +118,7 @@ static int log2(int x)
 
 bool OSSPlugin::set_buffer(String &error)
 {
-    int milliseconds = aud_get_int(nullptr, "output_buffer_size");
+    int milliseconds = aud_get_int("output_buffer_size");
     int bytes = frames_to_bytes(aud::rescale(milliseconds, 1000, m_rate));
     int fragorder = aud::clamp(log2(bytes / 4), 9, 15);
     int numfrags = aud::clamp(aud::rdiv(bytes, 1 << fragorder), 4, 32767);

--- a/src/playlist-manager-qt/playlist-manager-qt.cc
+++ b/src/playlist-manager-qt/playlist-manager-qt.cc
@@ -34,6 +34,8 @@
 #include <libaudqt/libaudqt.h>
 #include <libaudqt/treeview.h>
 
+#include "../ui-common/qt-compat.h"
+
 class PlaylistManagerQt : public GeneralPlugin
 {
 public:
@@ -295,10 +297,10 @@ void PlaylistsView::dropEvent(QDropEvent * event)
     switch (dropIndicatorPosition())
     {
     case AboveItem:
-        to = indexAt(event->pos()).row();
+        to = indexAt(QtCompat::pos(event)).row();
         break;
     case BelowItem:
-        to = indexAt(event->pos()).row() + 1;
+        to = indexAt(QtCompat::pos(event)).row() + 1;
         break;
     case OnViewport:
         to = Playlist::n_playlists();

--- a/src/qtui/playlist-qt.cc
+++ b/src/qtui/playlist-qt.cc
@@ -32,6 +32,7 @@
 #include "playlist_model.h"
 
 #include "../ui-common/menu-ops.h"
+#include "../ui-common/qt-compat.h"
 
 PlaylistWidget::PlaylistWidget(QWidget * parent, Playlist playlist)
     : audqt::TreeView(parent), m_playlist(playlist),
@@ -228,10 +229,10 @@ void PlaylistWidget::dropEvent(QDropEvent * event)
     switch (dropIndicatorPosition())
     {
     case AboveItem:
-        to = indexToRow(indexAt(event->pos()));
+        to = indexToRow(indexAt(QtCompat::pos(event)));
         break;
     case BelowItem:
-        to = indexToRow(indexAt(event->pos())) + 1;
+        to = indexToRow(indexAt(QtCompat::pos(event))) + 1;
         break;
     case OnViewport:
         to = m_playlist.n_entries();

--- a/src/skins-qt/drag-handle.cc
+++ b/src/skins-qt/drag-handle.cc
@@ -22,14 +22,16 @@
 #include "drag-handle.h"
 #include "skins_cfg.h"
 
+#include "../ui-common/qt-compat.h"
+
 bool DragHandle::button_press (QMouseEvent * event)
 {
     if (event->button () != Qt::LeftButton)
         return false;
 
     m_held = true;
-    m_x_origin = event->globalX ();
-    m_y_origin = event->globalY ();
+    m_x_origin = QtCompat::globalX (event);
+    m_y_origin = QtCompat::globalY (event);
 
     if (press)
         press ();
@@ -52,8 +54,8 @@ bool DragHandle::motion (QMouseEvent * event)
         return true;
 
     if (drag)
-        drag ((event->globalX () - m_x_origin) / config.scale,
-         (event->globalY () - m_y_origin) / config.scale);
+        drag ((QtCompat::globalX (event) - m_x_origin) / config.scale,
+         (QtCompat::globalY (event) - m_y_origin) / config.scale);
 
     return true;
 }

--- a/src/skins-qt/eq-graph.cc
+++ b/src/skins-qt/eq-graph.cc
@@ -88,7 +88,7 @@ void EqGraph::draw (QPainter & cr)
         return;
 
     skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 294, 0, 0, 113, 19);
-    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 314, 0, 9 + (aud_get_double (nullptr,
+    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 314, 0, 9 + (aud_get_double (
      "equalizer_preamp") * 9 + AUD_EQ_MAX_GAIN / 2) / AUD_EQ_MAX_GAIN, 113, 1);
 
     double bands[N];

--- a/src/skins-qt/eq-slider.cc
+++ b/src/skins-qt/eq-slider.cc
@@ -32,6 +32,8 @@
 #include "skin.h"
 #include "eq-slider.h"
 
+#include "../ui-common/qt-compat.h"
+
 void EqSlider::draw (QPainter & cr)
 {
     int frame = 27 - m_pos * 27 / 50;
@@ -68,7 +70,7 @@ bool EqSlider::button_press (QMouseEvent * event)
         return false;
 
     m_pressed = true;
-    moved (event->y () / config.scale - 5);
+    moved (QtCompat::y (event) / config.scale - 5);
     queue_draw ();
     return true;
 }
@@ -82,7 +84,7 @@ bool EqSlider::button_release (QMouseEvent * event)
         return true;
 
     m_pressed = false;
-    moved (event->y () / config.scale - 5);
+    moved (QtCompat::y (event) / config.scale - 5);
     queue_draw ();
     return true;
 }
@@ -92,7 +94,7 @@ bool EqSlider::motion (QMouseEvent * event)
     if (! m_pressed)
         return true;
 
-    moved (event->y () / config.scale - 5);
+    moved (QtCompat::y (event) / config.scale - 5);
     queue_draw ();
     return true;
 }

--- a/src/skins-qt/equalizer.cc
+++ b/src/skins-qt/equalizer.cc
@@ -46,6 +46,8 @@
 #include "skins_util.h"
 #include "view.h"
 
+#include "../ui-common/qt-compat.h"
+
 class EqWindow : public Window
 {
 public:
@@ -96,7 +98,7 @@ bool EqWindow::button_press (QMouseEvent * event)
 {
     if (event->button () == Qt::LeftButton &&
      event->type () == QEvent::MouseButtonDblClick &&
-     event->y () < 14 * config.scale)
+     QtCompat::y (event) < 14 * config.scale)
     {
         equalizerwin_shade_toggle ();
         return true;
@@ -104,7 +106,7 @@ bool EqWindow::button_press (QMouseEvent * event)
 
     if (event->button () == Qt::RightButton && event->type () == QEvent::MouseButtonPress)
     {
-        menu_popup (UI_MENU_MAIN, event->globalX (), event->globalY (), false, false);
+        menu_popup (UI_MENU_MAIN, QtCompat::globalX (event), QtCompat::globalY (event), false, false);
         return true;
     }
 

--- a/src/skins-qt/hslider.cc
+++ b/src/skins-qt/hslider.cc
@@ -30,6 +30,8 @@
 #include "skins_cfg.h"
 #include "hslider.h"
 
+#include "../ui-common/qt-compat.h"
+
 void HSlider::draw (QPainter & cr)
 {
     skin_draw_pixbuf (cr, m_si, m_fx, m_fy, 0, 0, m_w, m_h);
@@ -46,7 +48,7 @@ bool HSlider::button_press (QMouseEvent * event)
         return false;
 
     m_pressed = true;
-    m_pos = aud::clamp ((int) event->x () / config.scale - m_kw / 2, m_min, m_max);
+    m_pos = aud::clamp ((int) QtCompat::x (event) / config.scale - m_kw / 2, m_min, m_max);
 
     if (move)
         move ();
@@ -64,7 +66,7 @@ bool HSlider::button_release (QMouseEvent * event)
         return true;
 
     m_pressed = false;
-    m_pos = aud::clamp ((int) event->x () / config.scale - m_kw / 2, m_min, m_max);
+    m_pos = aud::clamp ((int) QtCompat::x (event) / config.scale - m_kw / 2, m_min, m_max);
 
     if (release)
         release ();
@@ -79,7 +81,7 @@ bool HSlider::motion (QMouseEvent * event)
         return true;
 
     m_pressed = true;
-    m_pos = aud::clamp ((int) event->x () / config.scale - m_kw / 2, m_min, m_max);
+    m_pos = aud::clamp ((int) QtCompat::x (event) / config.scale - m_kw / 2, m_min, m_max);
 
     if (move)
         move ();

--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -38,6 +38,7 @@
 #include <libaudqt/libaudqt.h>
 
 #include "../ui-common/dialogs-qt.h"
+#include "../ui-common/qt-compat.h"
 
 #include "actions-mainwin.h"
 #include "actions-playlist.h"
@@ -498,7 +499,7 @@ bool MainWindow::button_press (QMouseEvent * event)
 {
     if (event->button () == Qt::LeftButton &&
      event->type () == QEvent::MouseButtonDblClick &&
-     event->y () < 14 * config.scale)
+     QtCompat::y (event) < 14 * config.scale)
     {
         mainwin_shade_toggle ();
         return true;
@@ -506,7 +507,7 @@ bool MainWindow::button_press (QMouseEvent * event)
 
     if (event->button () == Qt::RightButton && event->type () == QEvent::MouseButtonPress)
     {
-        menu_popup (UI_MENU_MAIN, event->globalX (), event->globalY (), false, false);
+        menu_popup (UI_MENU_MAIN, QtCompat::globalX (event), QtCompat::globalY (event), false, false);
         return true;
     }
 
@@ -524,8 +525,8 @@ void MainWindow::enterEvent (QEvent * event)
     if (! is_shaded() || ! aud_get_bool (nullptr, "show_filepopup_for_tuple"))
         return;
 
-    if (enterEvent->x () >= 79 * config.scale &&
-        enterEvent->x () <= 157 * config.scale)
+    if (QtCompat::x (enterEvent) >= 79 * config.scale &&
+        QtCompat::x (enterEvent) <= 157 * config.scale)
     {
         audqt::infopopup_show_current ();
     }
@@ -533,7 +534,7 @@ void MainWindow::enterEvent (QEvent * event)
 
 static void mainwin_playback_rpress (Button * button, QMouseEvent * event)
 {
-    menu_popup (UI_MENU_PLAYBACK, event->globalX (), event->globalY (), false, false);
+    menu_popup (UI_MENU_PLAYBACK, QtCompat::globalX (event), QtCompat::globalY (event), false, false);
 }
 
 bool Window::keypress (QKeyEvent * event)
@@ -850,7 +851,7 @@ void mainwin_mr_release (MenuRowItem i, QMouseEvent * event)
     switch (i)
     {
         case MENUROW_OPTIONS:
-            menu_popup (UI_MENU_VIEW, event->globalX (), event->globalY (), false, false);
+            menu_popup (UI_MENU_VIEW, QtCompat::globalX (event), QtCompat::globalY (event), false, false);
             break;
         case MENUROW_ALWAYS:
             view_set_on_top (! aud_get_bool ("skins", "always_on_top"));
@@ -884,7 +885,7 @@ static bool mainwin_info_button_press (QMouseEvent * event)
 {
     if (event->type () == QEvent::MouseButtonPress && event->button () == Qt::RightButton)
     {
-        menu_popup (UI_MENU_PLAYBACK, event->globalX (), event->globalY (), false, false);
+        menu_popup (UI_MENU_PLAYBACK, QtCompat::globalX (event), QtCompat::globalY (event), false, false);
         return true;
     }
 

--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -522,7 +522,7 @@ void MainWindow::enterEvent (QEvent * event)
 {
     auto enterEvent = static_cast<QEnterEvent *> (event);
 #endif
-    if (! is_shaded() || ! aud_get_bool (nullptr, "show_filepopup_for_tuple"))
+    if (! is_shaded () || ! aud_get_bool ("show_filepopup_for_tuple"))
         return;
 
     if (QtCompat::x (enterEvent) >= 79 * config.scale &&

--- a/src/skins-qt/menurow.cc
+++ b/src/skins-qt/menurow.cc
@@ -31,6 +31,8 @@
 #include "skin.h"
 #include "menurow.h"
 
+#include "../ui-common/qt-compat.h"
+
 void MenuRow::draw (QPainter & cr)
 {
     if (m_selected == MENUROW_NONE)
@@ -77,7 +79,7 @@ bool MenuRow::button_press (QMouseEvent * event)
         return false;
 
     m_pushed = true;
-    m_selected = menurow_find_selected (event->x () / config.scale, event->y () / config.scale);
+    m_selected = menurow_find_selected (QtCompat::x (event) / config.scale, QtCompat::y (event) / config.scale);
 
     mainwin_mr_change (m_selected);
 
@@ -107,7 +109,7 @@ bool MenuRow::motion (QMouseEvent * event)
     if (! m_pushed)
         return true;
 
-    m_selected = menurow_find_selected (event->x () / config.scale, event->y () / config.scale);
+    m_selected = menurow_find_selected (QtCompat::x (event) / config.scale, QtCompat::y (event) / config.scale);
 
     mainwin_mr_change (m_selected);
 

--- a/src/skins-qt/playlist-slider.cc
+++ b/src/skins-qt/playlist-slider.cc
@@ -33,6 +33,8 @@
 #include "playlist-widget.h"
 #include "playlist-slider.h"
 
+#include "../ui-common/qt-compat.h"
+
 void PlaylistSlider::draw (QPainter & cr)
 {
     int rows, first;
@@ -69,7 +71,7 @@ bool PlaylistSlider::button_press (QMouseEvent * event)
         return false;
 
     m_pressed = true;
-    set_pos (event->y () / config.scale - 9);
+    set_pos (QtCompat::y (event) / config.scale - 9);
 
     queue_draw ();
     return true;
@@ -84,7 +86,7 @@ bool PlaylistSlider::button_release (QMouseEvent * event)
         return true;
 
     m_pressed = false;
-    set_pos (event->y () / config.scale - 9);
+    set_pos (QtCompat::y (event) / config.scale - 9);
 
     queue_draw ();
     return true;
@@ -95,7 +97,7 @@ bool PlaylistSlider::motion (QMouseEvent * event)
     if (! m_pressed)
         return true;
 
-    set_pos (event->y () / config.scale - 9);
+    set_pos (QtCompat::y (event) / config.scale - 9);
 
     queue_draw ();
     return true;

--- a/src/skins-qt/playlist-widget.cc
+++ b/src/skins-qt/playlist-widget.cc
@@ -33,6 +33,8 @@
 #include "playlist-widget.h"
 #include "playlist-slider.h"
 
+#include "../ui-common/qt-compat.h"
+
 #include <libaudcore/audstrings.h>
 #include <libaudcore/drct.h>
 #include <libaudcore/hook.h>
@@ -589,7 +591,7 @@ int PlaylistWidget::hover_end ()
 
 bool PlaylistWidget::button_press (QMouseEvent * event)
 {
-    int position = calc_position (event->y ());
+    int position = calc_position (QtCompat::y (event));
     int state = event->modifiers () & (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier);
 
     cancel_all ();
@@ -639,7 +641,7 @@ bool PlaylistWidget::button_press (QMouseEvent * event)
             }
 
             menu_popup ((position == -1) ? UI_MENU_PLAYLIST :
-             UI_MENU_PLAYLIST_CONTEXT, event->globalX (), event->globalY (),
+             UI_MENU_PLAYLIST_CONTEXT, QtCompat::globalX (event), QtCompat::globalY (event),
              false, false);
             break;
           default:
@@ -691,7 +693,7 @@ void PlaylistWidget::scroll_timeout ()
 
 bool PlaylistWidget::motion (QMouseEvent * event)
 {
-    int position = calc_position (event->y ());
+    int position = calc_position (QtCompat::y (event));
 
     if (m_drag)
     {
@@ -748,7 +750,7 @@ void PlaylistWidget::dragMoveEvent (QDragMoveEvent * event)
 
     if (event->proposedAction () == Qt::CopyAction && mimedata->hasUrls ())
     {
-        auto p = event->pos ();
+        auto p = QtCompat::pos (event);
         hover (p.x (), p.y ());
         event->acceptProposedAction ();
     }
@@ -765,7 +767,7 @@ void PlaylistWidget::dropEvent (QDropEvent * event)
 
     if (event->proposedAction () == Qt::CopyAction && mimedata->hasUrls ())
     {
-        auto p = event->pos ();
+        auto p = QtCompat::pos (event);
         hover (p.x (), p.y ());
 
         Index<PlaylistAddItem> files;

--- a/src/skins-qt/playlistwin.cc
+++ b/src/skins-qt/playlistwin.cc
@@ -49,6 +49,8 @@
 #include "window.h"
 #include "view.h"
 
+#include "../ui-common/qt-compat.h"
+
 #define PLAYLISTWIN_MIN_WIDTH           MAINWIN_WIDTH
 #define PLAYLISTWIN_MIN_HEIGHT          MAINWIN_HEIGHT
 #define PLAYLISTWIN_WIDTH_SNAP          25
@@ -223,7 +225,7 @@ bool PlWindow::scroll (QWheelEvent * event)
 bool PlWindow::button_press (QMouseEvent * event)
 {
     if (event->button () == Qt::LeftButton &&
-     event->type () == QEvent::MouseButtonDblClick && event->y () < 14)
+     event->type () == QEvent::MouseButtonDblClick && QtCompat::y (event) < 14)
     {
         playlistwin_shade_toggle ();
         return true;
@@ -231,7 +233,7 @@ bool PlWindow::button_press (QMouseEvent * event)
 
     if (event->button () == Qt::RightButton && event->type () == QEvent::MouseButtonPress)
     {
-        menu_popup (UI_MENU_PLAYLIST, event->globalX (), event->globalY (), false, false);
+        menu_popup (UI_MENU_PLAYLIST, QtCompat::globalX (event), QtCompat::globalY (event), false, false);
         return true;
     }
 

--- a/src/skins-qt/window.cc
+++ b/src/skins-qt/window.cc
@@ -23,6 +23,8 @@
 #include "plugin.h"
 #include "skins_cfg.h"
 
+#include "../ui-common/qt-compat.h"
+
 void Window::apply_shape ()
 {
     QRegion * mask = m_is_shaded ? m_sshape.get () : m_shape.get ();
@@ -41,7 +43,7 @@ bool Window::button_press (QMouseEvent * event)
     if (m_is_moving)
         return true;
 
-    dock_move_start (m_id, event->globalX (), event->globalY ());
+    dock_move_start (m_id, QtCompat::globalX (event), QtCompat::globalY (event));
     m_is_moving = true;
     return true;
 }
@@ -60,7 +62,7 @@ bool Window::motion (QMouseEvent * event)
     if (! m_is_moving)
         return true;
 
-    dock_move (event->globalX (), event->globalY ());
+    dock_move (QtCompat::globalX (event), QtCompat::globalY (event));
     return true;
 }
 

--- a/src/skins/eq-graph.cc
+++ b/src/skins/eq-graph.cc
@@ -88,7 +88,7 @@ void EqGraph::draw (cairo_t * cr)
         return;
 
     skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 294, 0, 0, 113, 19);
-    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 314, 0, 9 + (aud_get_double (nullptr,
+    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 314, 0, 9 + (aud_get_double (
      "equalizer_preamp") * 9 + AUD_EQ_MAX_GAIN / 2) / AUD_EQ_MAX_GAIN, 113, 1);
 
     double bands[N];

--- a/src/ui-common/qt-compat.h
+++ b/src/ui-common/qt-compat.h
@@ -1,0 +1,110 @@
+/*
+ * qt-compat.h
+ * Copyright 2023 Thomas Lange
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the documentation
+ *    provided with the distribution.
+ *
+ * This software is provided "as is" and without any warranty, express or
+ * implied. In no event shall the authors be liable for any damages arising from
+ * the use of this software.
+ */
+
+#ifndef UI_COMMON_QT_COMPAT_H
+#define UI_COMMON_QT_COMPAT_H
+
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QEnterEvent>
+#include <QMouseEvent>
+#include <QtGlobal>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  #define USE_QT6
+#endif
+
+namespace QtCompat
+{
+
+static inline int x (QEnterEvent * event)
+{
+#ifdef USE_QT6
+    return event->position ().x ();
+#else
+    return event->x ();
+#endif
+}
+
+static inline int y (QEnterEvent * event)
+{
+#ifdef USE_QT6
+    return event->position ().y ();
+#else
+    return event->y ();
+#endif
+}
+
+static inline int x (QMouseEvent * event)
+{
+#ifdef USE_QT6
+    return event->position ().x ();
+#else
+    return event->x ();
+#endif
+}
+
+static inline int y (QMouseEvent * event)
+{
+#ifdef USE_QT6
+    return event->position ().y ();
+#else
+    return event->y ();
+#endif
+}
+
+static inline int globalX (QMouseEvent * event)
+{
+#ifdef USE_QT6
+    return event->globalPosition ().x ();
+#else
+    return event->globalX ();
+#endif
+}
+
+static inline int globalY (QMouseEvent * event)
+{
+#ifdef USE_QT6
+    return event->globalPosition ().y ();
+#else
+    return event->globalY ();
+#endif
+}
+
+static inline QPoint pos (QDragMoveEvent * event)
+{
+#ifdef USE_QT6
+    return event->position ().toPoint ();
+#else
+    return event->pos ();
+#endif
+}
+
+static inline QPoint pos (QDropEvent * event)
+{
+#ifdef USE_QT6
+    return event->position ().toPoint ();
+#else
+    return event->pos ();
+#endif
+}
+
+} /* namespace QtCompat */
+
+#endif


### PR DESCRIPTION
For now it is sufficient to share this header internally.
In the future we may move it into libaudqt.