### PR TITLE
Support new songlengths db format in SID plugin 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,7 +300,7 @@ ENABLE_PLUGIN_WITH_DEP(sid,
     auto,
     INPUT,
     SIDPLAYFP,
-    libsidplayfp >= 1.0)
+    libsidplayfp >= 2.0)
 
 test_console () {
     AC_CHECK_HEADERS(zlib.h, have_console=yes, have_console=no)

--- a/src/sid/xmms-sid.cc
+++ b/src/sid/xmms-sid.cc
@@ -156,8 +156,8 @@ bool SIDPlugin::play(const char *filename, VFSFile &file)
     /* Check minimum playtime */
     int tmpLength = info.subTunes[subTune - 1].tuneLength;
     if (xs_cfg.playMinTimeEnable && (tmpLength >= 0)) {
-        if (tmpLength < xs_cfg.playMinTime)
-            tmpLength = xs_cfg.playMinTime;
+        if (tmpLength < xs_cfg.playMinTime * 1000)
+            tmpLength = xs_cfg.playMinTime * 1000;
     }
 
     /* Initialize song */
@@ -204,7 +204,7 @@ bool SIDPlugin::play(const char *filename, VFSFile &file)
         }
 
         if (tmpLength >= 0) {
-            if (time_played >= tmpLength * 1000)
+            if (time_played >= tmpLength)
                 break;
         }
     }
@@ -231,7 +231,7 @@ static void xs_get_song_tuple_info(Tuple &tuple, const xs_tuneinfo_t &info, int 
 
     if (subTune > 0 && subTune <= info.nsubTunes) {
         int tmpInt = info.subTunes[subTune - 1].tuneLength;
-        tuple.set_int (Tuple::Length, (tmpInt < 0) ? -1 : tmpInt * 1000);
+        tuple.set_int (Tuple::Length, (tmpInt < 0) ? -1 : tmpInt);
     } else
         subTune = 1;
 
@@ -248,7 +248,7 @@ static void xs_fill_subtunes(Tuple &tuple, const xs_tuneinfo_t &info)
     for (int count = 0; count < info.nsubTunes; count++) {
         if (count + 1 == info.startTune || !xs_cfg.subAutoMinOnly ||
             info.subTunes[count].tuneLength < 0 ||
-            info.subTunes[count].tuneLength >= xs_cfg.subAutoMinTime)
+            info.subTunes[count].tuneLength >= xs_cfg.subAutoMinTime * 1000)
             subtunes.append (count + 1);
     }
 

--- a/src/sid/xs_sidplay2.cc
+++ b/src/sid/xs_sidplay2.cc
@@ -140,9 +140,9 @@ bool xs_sidplayfp_init()
     }
 
     /* Load ROMs */
-    VFSFile kernal_file("file://" SIDDATADIR "sidplayfp/kernal", "r");
-    VFSFile basic_file("file://" SIDDATADIR "sidplayfp/basic", "r");
-    VFSFile chargen_file("file://" SIDDATADIR "sidplayfp/chargen", "r");
+    VFSFile kernal_file("file://" SIDDATADIR "/sidplayfp/kernal", "r");
+    VFSFile basic_file("file://" SIDDATADIR "/sidplayfp/basic", "r");
+    VFSFile chargen_file("file://" SIDDATADIR "/sidplayfp/chargen", "r");
 
     if (kernal_file && basic_file && chargen_file)
     {
@@ -155,7 +155,7 @@ bool xs_sidplayfp_init()
     }
 
     /* Load song length database */
-    state.database_loaded = state.database.open(SIDDATADIR "sidplayfp/Songlengths.txt");
+    state.database_loaded = state.database.open(SIDDATADIR "/sidplayfp/Songlengths.md5");
 
     /* Create the sidtune */
     state.currTune = new SidTune(0);
@@ -257,7 +257,7 @@ bool xs_sidplayfp_getinfo(xs_tuneinfo_t &ti, const void *buf, int64_t bufSize)
         for (int i = 0; i < ti.nsubTunes; i++)
         {
             myTune.selectSong(i + 1);
-            ti.subTunes[i].tuneLength = state.database.length(myTune);
+            ti.subTunes[i].tuneLength = state.database.lengthMs(myTune);
         }
 
         pthread_mutex_unlock(&state.database_mutex);


### PR DESCRIPTION
Ref https://www.hvsc.c64.org/download/C64Music/DOCUMENTS/Songlengths.faq

HVSC 68 introduced new songlengths db format.
Since HVSC 71 the old format db is no longer included.

`SidDatabase::length()` apparently assumes old db format while `SidDatabase::lengthMs()` works with new format, so switch to using that.
See: https://github.com/libsidplayfp/sidplayfp/blob/d241d27938b0f1f9f8a10d172eab1073868728fd/src/player.cpp#L597

Also:
* fix ROM file and the songlength db search path, which was broken due to missing / at least when using custom install prefix with Meson build
* require libsidplayfp >= 2.0 also with autotools build (Meson build already requires it), since the new db format is only supported with version >= 2.0.0