### PR TITLE
ffaudio: Prevent warning about discarded samples

### DIFF
--- a/src/ffaudio/ffaudio-core.cc
+++ b/src/ffaudio/ffaudio-core.cc
@@ -89,6 +89,12 @@ struct ScopedContext
 #else
         ptr = cinfo.stream->codec;
 #endif
+
+#if CHECK_LIBAVCODEC_VERSION(58, 9, 100)
+    ptr->pkt_timebase = cinfo.stream->time_base;
+#else
+    av_codec_set_pkt_timebase (ptr, cinfo.stream->time_base);
+#endif
     }
 
 #ifdef ALLOC_CONTEXT


### PR DESCRIPTION
FFmpeg logs warnings as below when opening files if the packet timebase is not set. This affects for example WebM files downloaded from YouTube with yt-dlp.

These warnings are particularly distracting in the Qt interface where we show them in the status bar.

WARNING ../src/ffaudio/ffaudio-core.cc:201 [opus]: <0x7f849812ae40> Could not update timestamps for skipped samples.

See also:
- https://github.com/FFmpeg/FFmpeg/commit/889bc79b5f5cef757be3b23dd44c9908fc08330e
- https://github.com/aubio/aubio/issues/236
- https://www.itcodet.com/cpp/cpp-av_codec_set_pkt_timebase-function-examples.html