### PR TITLE
meson: Improve library detection

### DIFF
--- a/src/aac/meson.build
+++ b/src/aac/meson.build
@@ -1,5 +1,10 @@
-faad_dep = cxx.find_library('faad', required: false)
-have_aac = faad_dep.found() and cxx.has_header('neaacdec.h')
+faad_dep = dependency('faad2', required: false)
+
+if not faad_dep.found()
+  faad_dep = cxx.find_library('faad', has_headers: 'neaacdec.h',
+                              dirs: ['/usr/local/lib'], required: false)
+endif
+have_aac = faad_dep.found()
 
 
 if have_aac

--- a/src/aac/meson.build
+++ b/src/aac/meson.build
@@ -2,7 +2,7 @@ faad_dep = dependency('faad2', required: false)
 
 if not faad_dep.found()
   faad_dep = cxx.find_library('faad', has_headers: 'neaacdec.h',
-                              dirs: ['/usr/local/lib'], required: false)
+                              required: false)
 endif
 have_aac = faad_dep.found()
 

--- a/src/filewriter/meson.build
+++ b/src/filewriter/meson.build
@@ -34,9 +34,14 @@ endif
 
 
 if get_option('filewriter-mp3')
-  lame_dep = cxx.find_library('mp3lame', required: false)
+  lame_dep = dependency('mp3lame', required: false)
 
-  if lame_dep.found() and cxx.has_header('lame/lame.h')
+  if not lame_dep.found()
+    lame_dep = cxx.find_library('mp3lame', has_headers: 'lame/lame.h',
+                                dirs: ['/usr/local/lib'], required: false)
+  endif
+
+  if lame_dep.found()
     filewriter_deps += [lame_dep]
     filewriter_srcs += ['mp3.cc']
 

--- a/src/filewriter/meson.build
+++ b/src/filewriter/meson.build
@@ -34,7 +34,7 @@ endif
 
 
 if get_option('filewriter-mp3')
-  lame_dep = dependency('mp3lame', required: false)
+  lame_dep = dependency('lame', required: false)
 
   if not lame_dep.found()
     lame_dep = cxx.find_library('mp3lame', has_headers: 'lame/lame.h',

--- a/src/filewriter/meson.build
+++ b/src/filewriter/meson.build
@@ -38,7 +38,7 @@ if get_option('filewriter-mp3')
 
   if not lame_dep.found()
     lame_dep = cxx.find_library('mp3lame', has_headers: 'lame/lame.h',
-                                dirs: ['/usr/local/lib'], required: false)
+                                required: false)
   endif
 
   if lame_dep.found()

--- a/src/lirc/meson.build
+++ b/src/lirc/meson.build
@@ -2,7 +2,7 @@ lirc_dep = dependency('lirc', required: false)
 
 if not lirc_dep.found()
   lirc_dep = cxx.find_library('lirc_client', has_headers: 'lirc/lirc_client.h',
-                              dirs: ['/usr/local/lib'], required: false)
+                              required: false)
 endif
 have_lirc = lirc_dep.found()
 

--- a/src/lirc/meson.build
+++ b/src/lirc/meson.build
@@ -6,6 +6,7 @@ if not lirc_dep.found()
 endif
 have_lirc = lirc_dep.found()
 
+
 if have_lirc
   shared_module('lirc',
     'lirc.cc',

--- a/src/lirc/meson.build
+++ b/src/lirc/meson.build
@@ -1,13 +1,16 @@
-lirc_dep = cxx.find_library('lirc', required: false)
-have_lirc = lirc_dep.found() and cxx.has_header('lirc/lirc_client.h')
+lirc_dep = dependency('lirc', required: false)
 
+if not lirc_dep.found()
+  lirc_dep = cxx.find_library('lirc_client', has_headers: 'lirc/lirc_client.h',
+                              dirs: ['/usr/local/lib'], required: false)
+endif
+have_lirc = lirc_dep.found()
 
 if have_lirc
   shared_module('lirc',
     'lirc.cc',
     dependencies: [audacious_dep, glib_dep, lirc_dep],
     name_prefix: '',
-    link_args: ['-llirc_client'],
     install: true,
     install_dir: general_plugin_dir
   )


### PR DESCRIPTION
Fix detection of some libraries in FreeBSD

- Use `pkgconfig` to detect `faad` (using `faad2.pc`)
- Look for `mp3lame` and `lirc_client` in `/usr/local/lib` on FreeBSD
- Remove unneeded `link_args: ['-llirc_client']`, required arguments provided by `cxx.find_library()`