### PR TITLE
mpg123: avoid false positives with content based detection

### DIFF
--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -168,7 +168,7 @@ DecodeState::DecodeState(const char * filename, VFSFile & file, bool probing,
     if (mpg123_open_handle(dec, &file) < 0)
         goto err;
 
-    if (!stream && aud_get_bool("mpg123", "full_scan") && mpg123_scan(dec) < 0)
+    if (!stream && !probing && aud_get_bool("mpg123", "full_scan") && mpg123_scan(dec) < 0)
         goto err;
 
     while (1)

--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -54,7 +54,10 @@ public:
     static constexpr PluginInfo info = {N_("MPG123 Plugin"), PACKAGE, nullptr,
                                         &prefs};
     static constexpr InputInfo iinfo =
-        InputInfo(FlagWritesTag).with_exts(exts).with_mimes(mimes);
+        InputInfo(FlagWritesTag)
+            .with_exts(exts)
+            .with_mimes(mimes)
+            .with_priority(_AUD_PLUGIN_DEFAULT_PRIO + 1); // false positives with content based detection
 
     constexpr MPG123Plugin() : InputPlugin(info, iinfo) {}
 

--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -155,8 +155,12 @@ DecodeState::DecodeState(const char * filename, VFSFile & file, bool probing,
 
     long flags = DECODE_OPTIONS;
     /* be strict about junk data in file during content probe */
-    if (probing)
+    if (probing) {
         flags |= MPG123_NO_RESYNC;
+#if MPG123_API_VERSION >= 45
+        flags |= MPG123_NO_FRANKENSTEIN;
+#endif
+    }
     mpg123_param(dec, MPG123_ADD_FLAGS, flags, 0);
 
     mpg123_format_none(dec);

--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -192,6 +192,10 @@ DecodeState::DecodeState(const char * filename, VFSFile & file, bool probing,
         if (mpg123_info(dec, &info) != MPG123_OK)
             goto err;
 
+        // heuristic/sanity check to avoid false positives
+        if (probing && !stream && info.vbr == MPG123_CBR && info.bitrate <= 0)
+            goto err;
+
         return;
     }
 

--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -173,7 +173,7 @@ DecodeState::DecodeState(const char * filename, VFSFile & file, bool probing,
 
     while (1)
     {
-        if (mpg123_getformat(dec, &rate, &channels, &encoding) < 0)
+        if (mpg123_getformat(dec, &rate, &channels, &encoding) != MPG123_OK)
             goto err;
 
         int ret =
@@ -181,10 +181,10 @@ DecodeState::DecodeState(const char * filename, VFSFile & file, bool probing,
 
         if (ret == MPG123_NEW_FORMAT)
             continue;
-        if (ret < 0)
+        if (ret != MPG123_OK)
             goto err;
 
-        if (mpg123_info(dec, &info) < 0)
+        if (mpg123_info(dec, &info) != MPG123_OK)
             goto err;
 
         return;

--- a/src/mpg123/mpg123.cc
+++ b/src/mpg123/mpg123.cc
@@ -149,14 +149,15 @@ DecodeState::DecodeState(const char * filename, VFSFile & file, bool probing,
                          bool stream)
 {
     dec = mpg123_new(nullptr, nullptr);
-    mpg123_param(dec, MPG123_ADD_FLAGS, DECODE_OPTIONS, 0);
     mpg123_replace_reader_handle(dec, replace_read,
                                  stream ? replace_lseek_dummy : replace_lseek,
                                  nullptr);
 
+    long flags = DECODE_OPTIONS;
     /* be strict about junk data in file during content probe */
     if (probing)
-        mpg123_param(dec, MPG123_RESYNC_LIMIT, 0, 0);
+        flags |= MPG123_NO_RESYNC;
+    mpg123_param(dec, MPG123_ADD_FLAGS, flags, 0);
 
     mpg123_format_none(dec);
 


### PR DESCRIPTION
mpg123 detection has quite high false positive rate  when doing content based probing. This PR fixes at least some of them.

The actual improvement (in my testing) is due to this commit: https://github.com/audacious-media-player/audacious-plugins/pull/133/commits/a8933a05052ea2431ede48a86c5217c6adfa2eb4

Fixes false positives for example among these files: 
(MP2 falsely detected): http://ftp.modland.com/pub/modules/Delitracker%20Custom/TSM/donner/instr/sphere.x
(MP3 falsely detected): http://ftp.modland.com/pub/modules/Delitracker%20Custom/TSM/donner/instr/donner.x
More examples: https://ftp.modland.com/pub/modules/Zoundmonitor/Samples/

Also fixes https://redmine.audacious-media-player.org/issues/1188