### PR TITLE
Add a WM_WINDOW_ROLE property to toplevel X11 windows.

### DIFF
--- a/src/amidiplug/i_fileinfo.cc
+++ b/src/amidiplug/i_fileinfo.cc
@@ -152,6 +152,7 @@ bool i_fileinfo_gui (const char * filename_uri, VFSFile & file)
     /*****************************************************/
 
     fileinfowin = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_role (GTK_WINDOW (fileinfowin), "fileinfo");
     gtk_window_set_default_size (GTK_WINDOW (fileinfowin), 500, 400);
     gtk_window_set_type_hint (GTK_WINDOW (fileinfowin), GDK_WINDOW_TYPE_HINT_DIALOG);
     g_signal_connect (G_OBJECT (fileinfowin), "destroy", G_CALLBACK (gtk_widget_destroyed), &fileinfowin);
@@ -348,6 +349,7 @@ bool i_fileinfo_gui (const char * filename_uri, VFSFile & file)
 
     title = g_path_get_basename (filename_utf8);
     gtk_window_set_title (GTK_WINDOW (fileinfowin), title);
+    gtk_window_set_role (GTK_WINDOW (fileinfowin), "fileinfo");
     g_free (title);
     /* set the text for the filename header too */
     gtk_entry_set_text (GTK_ENTRY (title_name_v_entry), filename_utf8);

--- a/src/amidiplug/i_fileinfo.cc
+++ b/src/amidiplug/i_fileinfo.cc
@@ -349,7 +349,6 @@ bool i_fileinfo_gui (const char * filename_uri, VFSFile & file)
 
     title = g_path_get_basename (filename_utf8);
     gtk_window_set_title (GTK_WINDOW (fileinfowin), title);
-    gtk_window_set_role (GTK_WINDOW (fileinfowin), "fileinfo");
     g_free (title);
     /* set the text for the filename header too */
     gtk_entry_set_text (GTK_ENTRY (title_name_v_entry), filename_utf8);

--- a/src/delete-files/delete-files.cc
+++ b/src/delete-files/delete-files.cc
@@ -228,6 +228,7 @@ static void start_delete ()
         qdialog->setAttribute (Qt::WA_DeleteOnClose);
         qdialog->setIcon (QMessageBox::Question);
         qdialog->setWindowTitle (_("Delete Files"));
+        qdialog->setWindowRole ("message");
         qdialog->setText ((const char *) prompt);
 
         auto remove = new QPushButton (action, qdialog);

--- a/src/gtkui/layout.cc
+++ b/src/gtkui/layout.cc
@@ -357,6 +357,7 @@ static void item_add (Item * item)
         NULL_ON_DESTROY (item->window);
 
         gtk_window_set_title ((GtkWindow *) item->window, item->name);
+        gtk_window_set_role ((GtkWindow *) item->window, "manager");
         gtk_container_set_border_width ((GtkContainer *) item->window, 2);
 
         g_signal_connect_swapped (item->window, "delete-event", (GCallback)

--- a/src/gtkui/layout.cc
+++ b/src/gtkui/layout.cc
@@ -357,7 +357,7 @@ static void item_add (Item * item)
         NULL_ON_DESTROY (item->window);
 
         gtk_window_set_title ((GtkWindow *) item->window, item->name);
-        gtk_window_set_role ((GtkWindow *) item->window, "manager");
+        gtk_window_set_role ((GtkWindow *) item->window, "plugin");
         gtk_container_set_border_width ((GtkContainer *) item->window, 2);
 
         g_signal_connect_swapped (item->window, "delete-event", (GCallback)

--- a/src/gtkui/ui_gtk.cc
+++ b/src/gtkui/ui_gtk.cc
@@ -798,6 +798,7 @@ bool GtkUI::init ()
     pw_col_init ();
 
     window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_role ((GtkWindow *) window, "mainwindow");
 
     accel = gtk_accel_group_new ();
     gtk_window_add_accel_group ((GtkWindow *) window, accel);
@@ -954,7 +955,6 @@ bool GtkUI::init ()
     menu_tab = make_menu_tab (accel);
 
     add_dock_plugins ();
-    gtk_window_set_role ((GtkWindow *) window, "mainwindow");
 
     return true;
 }

--- a/src/gtkui/ui_gtk.cc
+++ b/src/gtkui/ui_gtk.cc
@@ -954,6 +954,7 @@ bool GtkUI::init ()
     menu_tab = make_menu_tab (accel);
 
     add_dock_plugins ();
+    gtk_window_set_role ((GtkWindow *) window, "mainwindow");
 
     return true;
 }

--- a/src/hotkey/gui.cc
+++ b/src/hotkey/gui.cc
@@ -262,6 +262,7 @@ static gboolean on_entry_button_press_event(GtkWidget * widget,
               "modifiers.\n\n"
               "Do you want to continue?"));
         gtk_window_set_title(GTK_WINDOW(dialog), _("Binding mouse buttons"));
+        gtk_window_set_role(GTK_WINDOW(dialog), "message");
         response = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_destroy(dialog);
         if (response != GTK_RESPONSE_YES)

--- a/src/qtui/main_window.cc
+++ b/src/qtui/main_window.cc
@@ -52,7 +52,7 @@ public:
     {
         setObjectName(item->id());
         setWindowTitle(item->name());
-        setWindowRole("manager");
+        setWindowRole("plugin");
         setWidget(item->widget());
         setContextMenuPolicy(Qt::PreventContextMenu);
 
@@ -196,7 +196,7 @@ MainWindow::MainWindow()
 
     setMenuBar(m_menubar);
     setDockNestingEnabled(true);
-    setWindowRole("manager");
+    setWindowRole("plugin");
 
     audqt::register_dock_host(this);
 

--- a/src/qtui/main_window.cc
+++ b/src/qtui/main_window.cc
@@ -52,6 +52,7 @@ public:
     {
         setObjectName(item->id());
         setWindowTitle(item->name());
+        setWindowRole("manager");
         setWidget(item->widget());
         setContextMenuPolicy(Qt::PreventContextMenu);
 
@@ -195,6 +196,7 @@ MainWindow::MainWindow()
 
     setMenuBar(m_menubar);
     setDockNestingEnabled(true);
+    setWindowRole("manager");
 
     audqt::register_dock_host(this);
 

--- a/src/qtui/main_window.cc
+++ b/src/qtui/main_window.cc
@@ -196,7 +196,7 @@ MainWindow::MainWindow()
 
     setMenuBar(m_menubar);
     setDockNestingEnabled(true);
-    setWindowRole("plugin");
+    setWindowRole("mainwindow");
 
     audqt::register_dock_host(this);
 

--- a/src/skins-qt/equalizer.cc
+++ b/src/skins-qt/equalizer.cc
@@ -268,6 +268,7 @@ static void equalizerwin_create_window ()
 
     equalizerwin = new EqWindow (shaded);
     equalizerwin->setWindowTitle (_("Audacious Equalizer"));
+    equalizerwin->setWindowRole ("equalizer");
 }
 
 void equalizerwin_unhook ()

--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -1115,6 +1115,7 @@ static void mainwin_create_window ()
     bool shaded = aud_get_bool ("skins", "player_shaded");
 
     mainwin = new MainWindow (shaded);
+    mainwin->setWindowRole("mainwindow");
 
 #if 0
     GtkWidget * w = mainwin->gtk ();

--- a/src/skins-qt/playlistwin.cc
+++ b/src/skins-qt/playlistwin.cc
@@ -476,7 +476,7 @@ static void playlistwin_create_window ()
 
     playlistwin = new PlWindow (shaded);
     playlistwin->setWindowTitle (_("Audacious Playlist Editor"));
-    playlistwin->setWindowRole ("editor");
+    playlistwin->setWindowRole ("playlist");
 
 #if 0
     GtkWidget * w = playlistwin->gtk ();

--- a/src/skins-qt/playlistwin.cc
+++ b/src/skins-qt/playlistwin.cc
@@ -476,6 +476,7 @@ static void playlistwin_create_window ()
 
     playlistwin = new PlWindow (shaded);
     playlistwin->setWindowTitle (_("Audacious Playlist Editor"));
+    playlistwin->setWindowRole ("editor");
 
 #if 0
     GtkWidget * w = playlistwin->gtk ();

--- a/src/skins-qt/plugin-window.cc
+++ b/src/skins-qt/plugin-window.cc
@@ -46,6 +46,7 @@ public:
     {
         setWindowFlags (Qt::Dialog);
         setWindowTitle (item->name ());
+        setWindowRole ("plugin");
 
         item->set_host_data (this);
 

--- a/src/skins-qt/search-select.cc
+++ b/src/skins-qt/search-select.cc
@@ -60,6 +60,7 @@ private:
 SearchSelectDialog::SearchSelectDialog (QWidget * parent) : QDialog (parent)
 {
     setWindowTitle (_("Search entries in active playlist"));
+    setWindowRole ("search");
     setContentsMargins (audqt::margins.FourPt);
 
     auto logo = new QLabel;

--- a/src/skins/equalizer.cc
+++ b/src/skins/equalizer.cc
@@ -268,6 +268,7 @@ static void equalizerwin_create_window ()
 
     equalizerwin = new EqWindow (shaded);
     equalizerwin->setWindowTitle (_("Audacious Equalizer"));
+    equalizerwin->setWindowRole ("equalizer");
 }
 
 void equalizerwin_unhook ()

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -1159,6 +1159,7 @@ static void mainwin_create_window ()
     bool shaded = aud_get_bool ("skins", "player_shaded");
 
     mainwin = new MainWindow (shaded);
+    mainwin->setWindowRole("mainwindow");
 
     GtkWidget * w = mainwin->gtk ();
     drag_dest_set (w);

--- a/src/skins/playlistwin.cc
+++ b/src/skins/playlistwin.cc
@@ -489,7 +489,7 @@ static void playlistwin_create_window ()
 
     playlistwin = new PlWindow (shaded);
     playlistwin->setWindowTitle (_("Audacious Playlist Editor"));
-    playlistwin->setWindowRole ("editor");
+    playlistwin->setWindowRole ("playlist");
 
     GtkWidget * w = playlistwin->gtk ();
     drag_dest_set (w);

--- a/src/skins/playlistwin.cc
+++ b/src/skins/playlistwin.cc
@@ -489,7 +489,7 @@ static void playlistwin_create_window ()
 
     playlistwin = new PlWindow (shaded);
     playlistwin->setWindowTitle (_("Audacious Playlist Editor"));
-    playlistwin->setWindowTitle ("editor");
+    playlistwin->setWindowRole ("editor");
 
     GtkWidget * w = playlistwin->gtk ();
     drag_dest_set (w);

--- a/src/skins/playlistwin.cc
+++ b/src/skins/playlistwin.cc
@@ -489,6 +489,7 @@ static void playlistwin_create_window ()
 
     playlistwin = new PlWindow (shaded);
     playlistwin->setWindowTitle (_("Audacious Playlist Editor"));
+    playlistwin->setWindowTitle ("editor");
 
     GtkWidget * w = playlistwin->gtk ();
     drag_dest_set (w);

--- a/src/skins/plugin-window.cc
+++ b/src/skins/plugin-window.cc
@@ -62,6 +62,7 @@ static void add_dock_plugin (PluginHandle * plugin, void * unused)
     {
         GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
         gtk_window_set_title ((GtkWindow *) window, aud_plugin_get_name (plugin));
+        gtk_window_set_role ((GtkWindow *) window, "plugin");
         gtk_window_set_transient_for ((GtkWindow *) window, (GtkWindow *) mainwin->gtk ());
         gtk_container_set_border_width ((GtkContainer *) window, 2);
         gtk_container_add ((GtkContainer *) window, widget);

--- a/src/skins/window.cc
+++ b/src/skins/window.cc
@@ -93,7 +93,6 @@ Window::Window (int id, int * x, int * y, int w, int h, bool shaded) :
     h *= config.scale;
 
     GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-    gtk_window_set_role ((GtkWindow *) window, "skin");
     gtk_window_set_decorated ((GtkWindow *) window, false);
     gtk_window_set_resizable ((GtkWindow *) window, false);
     gtk_window_move ((GtkWindow *) window, * x, * y);

--- a/src/skins/window.cc
+++ b/src/skins/window.cc
@@ -93,6 +93,7 @@ Window::Window (int id, int * x, int * y, int w, int h, bool shaded) :
     h *= config.scale;
 
     GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_role ((GtkWindow *) window, "skin");
     gtk_window_set_decorated ((GtkWindow *) window, false);
     gtk_window_set_resizable ((GtkWindow *) window, false);
     gtk_window_move ((GtkWindow *) window, * x, * y);

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -52,6 +52,8 @@ public:
 
     void setWindowTitle (const char * title)
         { gtk_window_set_title ((GtkWindow *) gtk (), title); }
+    void setWindowRole (const char * role)
+        { gtk_window_set_role ((GtkWindow *) gtk (), role); }
     void getPosition (int * x, int * y)
         { gtk_window_get_position ((GtkWindow *) gtk (), x, y); }
     void move (int x, int y)

--- a/src/ui-common/dialogs-qt.cc
+++ b/src/ui-common/dialogs-qt.cc
@@ -50,6 +50,7 @@ void DialogWindows::create_progress ()
         m_progress->setAttribute (Qt::WA_DeleteOnClose);
         m_progress->setIcon (QMessageBox::Information);
         m_progress->setWindowTitle (_("Working ..."));
+        m_progress->setWindowRole ("progress");
         m_progress->setWindowModality (Qt::WindowModal);
     }
 }


### PR DESCRIPTION
With window managers like icewm and i3 users can configure window specific settings. For this to work toplevel windows must be distinguishable by a X11 property. Because Audacious uses the same WM_CLASS property for all its windows, the WM_WINDOW_ROLE property must be set. However, Audacious currently does not set this property. It is defined in the ICCCM manual for X11 clients. This patch sets this property on Gtk and Qt toplevel windows using designated library calls.