### PR TITLE
meson: Use cross platform approach to search and link libintl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,6 @@ copyright = 'Copyright (C) 2001-2023 Audacious developers and others'
 
 
 have_darwin = host_machine.system() == 'darwin'
-have_freebsd = host_machine.system() == 'freebsd'
 have_windows = host_machine.system() == 'windows'
 
 
@@ -139,13 +138,21 @@ else
 endif
 
 
-# XXX - why do we have to define this manually?
-if (cxx.has_header('libintl.h'))
-  add_project_arguments('-DHAVE_GETTEXT', language: ['c', 'cpp'])
-
-  if have_darwin or have_freebsd or have_windows
-    add_project_link_arguments('-lintl', language: ['c', 'cpp'])
+if meson.version().version_compare('>= 0.59')
+  intl_dep = dependency('intl', required: false)
+  intl_found = intl_dep.found()
+else
+  if cxx.has_function('ngettext', prefix: '#include <libintl.h>')
+    intl_dep = dependency('', required: false)
+    intl_found = true
+  else
+    intl_dep = cxx.find_library('intl', required: false)
+    intl_found = intl_dep.found()
   endif
+endif
+
+if intl_found
+  conf.set10('HAVE_GETTEXT', true)
 endif
 
 

--- a/src/config.h.meson
+++ b/src/config.h.meson
@@ -7,6 +7,8 @@
 #define PACKAGE_VERSION VERSION
 #define ICONV_CONST
 
+#mesondefine HAVE_GETTEXT
+
 #mesondefine INSTALL_BINDIR
 #mesondefine INSTALL_DATADIR
 #mesondefine INSTALL_PLUGINDIR


### PR DESCRIPTION
Depends on https://github.com/audacious-media-player/audacious/pull/62 to include `-lintl` in audacious.pc, required for BSD, macOS and Windows.