### PR TITLE
psf: Use snprintf instead of insecure sprintf

### DIFF
--- a/src/psf/eng_psf2.cc
+++ b/src/psf/eng_psf2.cc
@@ -399,7 +399,7 @@ static dump_files(int fs, uint8_t *buf, uint32_t buflen)
 				uofs += dlength;
 			}
 
-			sprintf(tfn, "iopfiles/%s", cptr);
+			snprintf(tfn, sizeof tfn, "iopfiles/%s", cptr);
 			f = fopen(tfn, "wb");
 			fwrite(buf, uncomp, 1, f);
 			fclose(f);

--- a/src/psf/psx.cc
+++ b/src/psf/psx.cc
@@ -209,7 +209,7 @@ static void GTELOG(const char *a,...)
 	va_list va;
 	char s_text[ 1024 ];
 	va_start( va, a );
-	vsprintf( s_text, a, va );
+	vsnprintf( s_text, sizeof s_text, a, va );
 	va_end( va );
 	logerror( "%08x: GTE: %08x %s\n", mipscpu.pc, INS_COFUN( mipscpu.op ), s_text );
 }
@@ -1721,7 +1721,7 @@ static offs_t mips_dasm( char *buffer, offs_t pc )
 #ifdef MAME_DEBUG
 	ret = DasmMIPS( buffer, pc );
 #else
-	sprintf( buffer, "$%08x", cpu_readop32( pc ) );
+	snprintf( buffer, 10, "$%08x", cpu_readop32( pc ) );
 	ret = 4;
 #endif
 	change_pc( mipscpu.pc );

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -2092,7 +2092,7 @@ static void iop_sprintf(char *out, char *fmt, uint32_t pstart)
 				mips_get_info(curparm, &mipsinfo);
 //				printf("parameter %d = %x\n", curparm-pstart, mipsinfo.i);
 				curparm++;
-				sprintf(temp, tfmt, (int32_t)mipsinfo.i);
+				snprintf(temp, sizeof temp, tfmt, (int32_t)mipsinfo.i);
 			}
 			else
 			{
@@ -2102,7 +2102,7 @@ static void iop_sprintf(char *out, char *fmt, uint32_t pstart)
 				pstr = (char *)psx_ram;
 				pstr += (mipsinfo.i & 0x1fffff);
 
-				sprintf(temp, tfmt, pstr);
+				snprintf(temp, sizeof temp, tfmt, pstr);
 			}
 
 			pstr = &temp[0];


### PR DESCRIPTION
sprintf/vsprintf are deprecated since macOS 13.