### PR TITLE
Adding "radio station" like transitions.

### DIFF
--- a/src/crossfade/crossfade.cc
+++ b/src/crossfade/crossfade.cc
@@ -21,7 +21,7 @@
 #include <libaudcore/plugin.h>
 #include <libaudcore/preferences.h>
 #include <libaudcore/runtime.h>
-#include <bits/stdc++.h>
+#include <cmath>
 
 enum
 {
@@ -38,8 +38,6 @@ static const char * const crossfade_defaults[] = {
     "manual", "TRUE",
     "manual_length", "0.2",
     "no_fade_in", "TRUE",
-    "fade_out_override", "FALSE",
-    "fade_out_override_length", "4",
     "use_sigmoid", "TRUE",
     "sigmoid_steepness", "6",
     nullptr
@@ -65,12 +63,6 @@ static const PreferencesWidget crossfade_widgets[] = {
         WIDGET_CHILD),
     WidgetCheck (N_("No fade in"),
         WidgetBool ("crossfade", "no_fade_in")),
-    WidgetCheck (N_("Override Fade Out Length"),
-        WidgetBool ("crossfade", "fade_out_override")),
-    WidgetSpin (N_("Fade Out Length:"),
-        WidgetFloat ("crossfade", "fade_out_override_length"),
-        {0.1, 15, 0.1, N_("seconds")},
-        WIDGET_CHILD),
     WidgetCheck (N_("Use S-Curve for fades"),
         WidgetBool ("crossfade", "use_sigmoid")),
     WidgetSpin (N_("S-Curve Steepness:"),
@@ -225,14 +217,7 @@ static int buffer_for_adjusted_fadeout ()
 
     if (state != STATE_FLUSHED)
     {
-        if (aud_get_bool ("crossfade", "fade_out_override"))
-        {
-            overlap = aud_get_double ("crossfade", "fade_out_override_length");
-				double length = aud_get_double("crossfade", "length");
-				if (overlap > length)
-                overlap = length;
-        }
-        else if (aud_get_bool ("crossfade", "automatic"))
+        if (aud_get_bool ("crossfade", "automatic"))
             overlap = aud_get_double ("crossfade", "length");
     }
 
@@ -279,10 +264,7 @@ static void run_fadeout ()
     if (aud_get_bool("crossfade", "use_sigmoid"))
         ramp = &do_sramp;
 
-    if (aud_get_bool ("crossfade", "fade_out_override"))
-        ramp (buffer.begin (), buffer.len (), buffer_for_adjusted_fadeout (), 1.0, 0.0);
-    else
-        ramp (buffer.begin (), buffer.len (), buffer.len (), 1.0, 0.0);
+    ramp (buffer.begin (), buffer.len (), buffer.len (), 1.0, 0.0);
 
     state = STATE_FADEIN;
     fadein_point = 0;


### PR DESCRIPTION
Hi,

First let me say a huge thank you to the team that developed/maintains audacious!  This really seems to be a simple no-nonsense light weight audio player that "just works" (and on many platforms!)

I would call this pull request somewhat of a "work in progress" but I wanted to create a pull request to gauge interest as well as get feedback.

After tinkering with software another passion of mine is music and DJing.  I've been searching for years for an audio player that could do what the old "foo_continuator" plugin did for Foobar2000.  For years I've used an ancient version of Foobar2000 and that plugin to play "background music" or "cocktail hour" music at DJ gigs during the portions of the event that were not "dancing/high energy." 

It seems just about all audio players out there seem to implement "crossfade" the same way as a true X-fade.  While crossfading does happen when a DJ is (so-called "beatmaching") and mixing two songs keeping the rhythms together it usually does *NOT* when one is just playing back-to-back songs the way a broadcast radio station does.   From my experience, broadcast stations typically start the next program at full volume while fading out the previous program (radio automation software even usually stores an EOP - End of Program or EOM - End of Message tag in the media files telling the automation software exactly where to start the next program and start fading the previous).

My changes are probably a bit "hacky" as I'm brand new to the code base (please point out any places I've done something silly or dumb).  I believe the original functionality is preserved, but I've added a few new parameters to the configuration:

-  No Fade In:  The main reason for this change.  This boolean will instruct the plugin to NOT use the ramp/fade-in function for the incoming (next) program.  However, the ramp/fade-out function will still be used for the outgoing (current) program.

- Use S-Curve for fades:  Upon my initial listening tests against various types of musical programs (mostly commercial releases from the last 6 or so decades) the linear fade-out sounded "a little off" to my ears.  If I got my math right this should apply a Sigmoid or (S-Curve) function to the fade function: 1/(1+EXP(&lt;steepness&gt;\*(2\*i-length)/length))
-  S-Curve Steepness: Changes the &lt;steepness&gt; parameter in the sigmoid function above.  A lower number means a slower fade and higher is faster. This parameter does not affect the original linear style fades.
- Override Fade Out Length:  Included to allow for fade-outs shorter than the total "Overlap" length.  I'm not sure if this needs to stay as in my later testing the "Overlap" parameter was enough "configurability" to control the character of the transitions.
- Fade Out Length (seconds):  The length of the fade-out if "Override Fade Out Length" is set.

Am I going about this the correct/desired way or would this be better suited as a separate plugin?  I figured the crossfade plugin was somewhat "in charge" of program transitions so I figured the changes would be best made here.

One last thought:  Another consideration I had while working on these changes was implementing the reading of "Mixramp" tags (if they existed) in each media file and allow those tags to give fine or exact control over where the transition would occur (similar to the PROGRAM START/PROGRAM END tags used in radio automation software).  This would allow one to control the transition on specific files.  One use case might be a program or song that ends with a few quiet lyrics.  I've noticed that the plugin's transition can kind of "step on" those last few quiet lyrics at the end of a song that has them.

Sorry for the super long pull request message.  Feel free to tell me I'm going overboard on the "transitions" aspect of Audacious! :-)

Thanks again for a great audio player!