### PR TITLE
CYGWIN: meson: include waveout driver to plugins

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -266,7 +266,7 @@ if meson.version().version_compare('>= 0.53')
     'PulseAudio': get_variable('have_pulse', false),
     'Simple DirectMedia Layer': get_variable('have_sdlout', false),
     'Sndio': get_variable('have_sndio', false),
-    'Win32 waveOut': have_windows,
+    'Win32 waveOut': have_windows or have_cygwin,
     'FileWriter': get_option('filewriter'),
     '  -> MP3 encoding': conf.has('FILEWRITER_MP3'),
     '  -> Vorbis encoding': conf.has('FILEWRITER_VORBIS'),

--- a/src/meson.build
+++ b/src/meson.build
@@ -281,7 +281,7 @@ if get_option('sndio')
   subdir('sndio')
 endif
 
-if have_windows
+if have_windows or have_cygwin
   subdir('waveout')
 endif
 


### PR DESCRIPTION
Waveout driver can be compiled without troubles on CYGWIN.
This fix allows to use the player without using SDL or PortAudio, if the user wants.
