### PR TITLE
CYGWIN: meson: fix missing X11 dependencies.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,9 @@ math_dep = cxx.find_library('m', required: false)
 samplerate_dep = dependency('samplerate', required: false)
 xml_dep = dependency('libxml-2.0', required: false)
 
+xrender_dep = dependency('xrender', required: false)
+xcomposite_dep = dependency('xcomposite', required: false)
+
 
 if get_option('qt')
   if get_option('qt6')

--- a/src/aosd/meson.build
+++ b/src/aosd/meson.build
@@ -1,5 +1,7 @@
 x11_dep = dependency('x11', required: false, modules: ['xrender', 'xcomposite'])
-have_aosd = x11_dep.found()
+have_aosd = x11_dep.found() and \
+            xrender_dep.found() and \
+            xcomposite_dep.found()
 
 
 aosd_sources = [
@@ -17,7 +19,7 @@ aosd_sources = [
 if have_aosd
   shared_module('aosd',
     aosd_sources,
-    dependencies: [audacious_dep, audgui_dep, math_dep, gtk_dep, glib_dep, x11_dep],
+    dependencies: [audacious_dep, audgui_dep, math_dep, gtk_dep, glib_dep, x11_dep, xrender_dep, xcomposite_dep],
     name_prefix: '',
     install: true,
     install_dir: general_plugin_dir

--- a/src/glspectrum/meson.build
+++ b/src/glspectrum/meson.build
@@ -5,7 +5,7 @@ have_glspectrum = opengl_dep.found()
 if have_glspectrum
   shared_module('gl-spectrum',
     'gl-spectrum.cc',
-    dependencies: [audacious_dep, math_dep, gtk_dep, glib_dep, opengl_dep],
+    dependencies: [audacious_dep, math_dep, gtk_dep, glib_dep, opengl_dep, x11_dep],
     name_prefix: '',
     install: true,
     install_dir: visualization_plugin_dir

--- a/src/hotkey/meson.build
+++ b/src/hotkey/meson.build
@@ -16,7 +16,7 @@ hotkey_sources = [
 if have_hotkey
   shared_module('hotkey',
     hotkey_sources,
-    dependencies: [audacious_dep, audgui_dep, gtk_dep, glib_dep, gdk_x11_dep],
+    dependencies: [audacious_dep, audgui_dep, gtk_dep, glib_dep, gdk_x11_dep, x11_dep],
     name_prefix: '',
     install: true,
     install_dir: general_plugin_dir


### PR DESCRIPTION
When building audacious-plugins on CYGWIN, I got few errors when linking some plugins to the final executables.
This happens with these components:

AOSD
```
ld: src/aosd/aosd.dll.p/ghosd.c.o: in function `composite_find_argb_visual':
audacious-plugins/src/aosd/ghosd.c:66:(.text+0xfa): undefined reference to `XRenderFindVisualFormat'
ld: src/aosd/aosd.dll.p/ghosd.c.o: in function `ghosd_render':
audacious-plugins/src/aosd/ghosd.c:134:(.text+0x4fc): undefined reference to `XRenderFindVisualFormat'
audacious-plugins/src/aosd/ghosd.c:140:(.text+0x591): undefined reference to `XRenderFindVisualFormat'
ld: src/aosd/aosd.dll.p/ghosd.c.o: in function `ghosd_check_composite_ext':
audacious-plugins/src/aosd/ghosd.c:411:(.text+0xf1b): undefined reference to `XCompositeQueryExtension'
collect2: error: ld returned 1 exit status
```

GL-SPECTRUM
```
ld: src/glspectrum/gl-spectrum.dll.p/gl-spectrum.cc.o: in function `widget_realized':
audacious-plugins/src/glspectrum/gl-spectrum.cc:326:(.text+0xdda): undefined reference to `XFree'
collect2: error: ld returned 1 exit status
```

HOTKEY
```
ld: src/hotkey/hotkey.dll.p/grab.cc.o: in function `get_offending_modifiers':
audacious-plugins/src/hotkey/grab.cc:58:(.text+0x16): undefined reference to `XKeysymToKeycode'
ld: audacious-plugins/src/hotkey/grab.cc:59:(.text+0x27): undefined reference to `XKeysymToKeycode'
ld: audacious-plugins/src/hotkey/grab.cc:65:(.text+0x33): undefined reference to `XGetModifierMapping'
ld: audacious-plugins/src/hotkey/grab.cc:81:(.text+0x119): undefined reference to `XFreeModifiermap'
ld: src/hotkey/hotkey.dll.p/grab.cc.o: in function `grab_key':
audacious-plugins/src/hotkey/grab.cc:98:(.text+0x1c5): undefined reference to `XGrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:105:(.text+0x221): undefined reference to `XGrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:109:(.text+0x270): undefined reference to `XGrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:113:(.text+0x2bf): undefined reference to `XGrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:117:(.text+0x322): undefined reference to `XGrabKey'
ld: src/hotkey/hotkey.dll.p/grab.cc.o:audacious-plugins/src/hotkey/grab.cc:122: more undefined references to `XGrabKey' follow
ld: src/hotkey/hotkey.dll.p/grab.cc.o: in function `grab_key':
audacious-plugins/src/hotkey/grab.cc:138:(.text+0x4be): undefined reference to `XGrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:145:(.text+0x52e): undefined reference to `XGrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:150:(.text+0x591): undefined reference to `XGrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:155:(.text+0x5f4): undefined reference to `XGrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:160:(.text+0x669): undefined reference to `XGrabButton'
ld: src/hotkey/hotkey.dll.p/grab.cc.o:audacious-plugins/src/hotkey/grab.cc:166: more undefined references to `XGrabButton' follow
ld: src/hotkey/hotkey.dll.p/grab.cc.o: in function `grab_keys()':
audacious-plugins/src/hotkey/grab.cc:199:(.text+0x836): undefined reference to `XSync'
ld: audacious-plugins/src/hotkey/grab.cc:200:(.text+0x845): undefined reference to `XSetErrorHandler'
ld: audacious-plugins/src/hotkey/grab.cc:213:(.text+0x8cd): undefined reference to `XSync'
ld: audacious-plugins/src/hotkey/grab.cc:214:(.text+0x8d9): undefined reference to `XSetErrorHandler'
ld: src/hotkey/hotkey.dll.p/grab.cc.o: in function `ungrab_key':
audacious-plugins/src/hotkey/grab.cc:231:(.text+0x966): undefined reference to `XUngrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:237:(.text+0x9aa): undefined reference to `XUngrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:241:(.text+0x9e1): undefined reference to `XUngrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:245:(.text+0xa18): undefined reference to `XUngrabKey'
ld: audacious-plugins/src/hotkey/grab.cc:249:(.text+0xa63): undefined reference to `XUngrabKey'
ld: src/hotkey/hotkey.dll.p/grab.cc.o:audacious-plugins/src/hotkey/grab.cc:253: more undefined references to `XUngrabKey' follow
ld: src/hotkey/hotkey.dll.p/grab.cc.o: in function `ungrab_key':
audacious-plugins/src/hotkey/grab.cc:270:(.text+0xb85): undefined reference to `XUngrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:276:(.text+0xbc3): undefined reference to `XUngrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:280:(.text+0xbf4): undefined reference to `XUngrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:284:(.text+0xc25): undefined reference to `XUngrabButton'
ld: audacious-plugins/src/hotkey/grab.cc:288:(.text+0xc68): undefined reference to `XUngrabButton'
ld: src/hotkey/hotkey.dll.p/grab.cc.o:audacious-plugins/src/hotkey/grab.cc:293: more undefined references to `XUngrabButton' follow
ld: src/hotkey/hotkey.dll.p/grab.cc.o: in function `ungrab_keys()':
audacious-plugins/src/hotkey/grab.cc:325:(.text+0xda6): undefined reference to `XSync'
ld: audacious-plugins/src/hotkey/grab.cc:326:(.text+0xdb5): undefined reference to `XSetErrorHandler'
ld: audacious-plugins/src/hotkey/grab.cc:340:(.text+0xe3d): undefined reference to `XSync'
ld: audacious-plugins/src/hotkey/grab.cc:341:(.text+0xe49): undefined reference to `XSetErrorHandler'
ld: src/hotkey/hotkey.dll.p/gui.cc.o: in function `set_keytext':
audacious-plugins/src/hotkey/gui.cc:113:(.text+0x8e): undefined reference to `XkbKeycodeToKeysym'
ld: audacious-plugins/src/hotkey/gui.cc:121:(.text+0xc6): undefined reference to `XKeysymToString'
ld: src/hotkey/hotkey.dll.p/plugin.cc.o: in function `add_hotkey(_HotkeyConfiguration**, unsigned long, int, int, EVENT)':
audacious-plugins/src/hotkey/plugin.cc:301:(.text+0x44e): undefined reference to `XKeysymToKeycode'
collect2: error: ld returned 1 exit status
```

I did a tiny fix to their `meson.build` for adding the missing dependencies.
`hotkey` and `gl-spectrum` required only `x11_dep` to be added.
`aosd` has already `x11_dep`, but the linker is missing `xrender` and `xcomposite`.
Since I don't use meson, I'm not sure to have understood this line and why it doesn't includes needed libraries:

https://github.com/audacious-media-player/audacious-plugins/blob/90c1d9314be4617fada2abfff47441d4b11ed30b/src/aosd/meson.build#L1

so, I took the way `xrender` and `xcomposite` have been used into the build script of Chromium and I did the fix into the `meson.build` file for using them in the same way.

After these last fixes, all plugins are compiled successfully on CYGWIN and the player is perfectly usable.
