### PR TITLE
lyricwiki-qt: Add support for chartlyrics.com. Closes: #1217

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -859,7 +859,7 @@ if test "x$USE_QT" = "xyes" ; then
     echo "  Winamp Classic Interface:               yes"
     echo "  Album Art:                              yes"
     echo "  Blur Scope:                             yes"
-    echo "  LyricWiki viewer:                       yes"
+    echo "  Lyrics Viewer:                          yes"
     echo "  OpenGL Spectrum Analyzer:               $have_qtglspectrum"
     echo "  Playlist Manager:                       yes"
     echo "  Search Tool:                            yes"

--- a/src/lyricwiki-qt/lyricwiki.cc
+++ b/src/lyricwiki-qt/lyricwiki.cc
@@ -177,9 +177,10 @@ class FileProvider : public LyricProvider {
 public:
     FileProvider() {};
 
-    bool match (LyricsState state);
-    void fetch (LyricsState state);
-    String edit_uri (LyricsState state) { return String (); }
+    bool match (LyricsState state) override;
+    void fetch (LyricsState state) override;
+    String edit_uri (LyricsState state) override { return String (); }
+
     void save (LyricsState state);
     void cache (LyricsState state);
     void cache_fetch (LyricsState state);
@@ -342,9 +343,9 @@ class ChartLyricsProvider : public LyricProvider
 public:
     ChartLyricsProvider () {};
 
-    bool match (LyricsState state);
-    void fetch (LyricsState state);
-    String edit_uri (LyricsState state) { return m_lyric_url; }
+    bool match (LyricsState state) override;
+    void fetch (LyricsState state) override;
+    String edit_uri (LyricsState state) override { return m_lyric_url; }
 
 private:
     String match_uri (LyricsState state);
@@ -542,9 +543,9 @@ class LyricsOVHProvider : public LyricProvider {
 public:
     LyricsOVHProvider() {};
 
-    bool match (LyricsState state);
-    void fetch (LyricsState state);
-    String edit_uri (LyricsState state) { return String (); }
+    bool match (LyricsState state) override;
+    void fetch (LyricsState state) override;
+    String edit_uri (LyricsState state) override { return String (); }
 };
 
 bool LyricsOVHProvider::match (LyricsState state)


### PR DESCRIPTION
lyricwiki-qt: Add support for chartlyrics.com. Closes: #1217

lyrics.ovh has been unreliable in the past months.
Meanwhile it is working again but still has issues at times.

Offer chartlyrics.com as an alternative. It is also not perfect
with no support for HTTPS and lyrics for new songs are missing.
Hoever having a choice is still better. And it is free for
non-commercial use, unlike many other sites.

See also:
- http://www.chartlyrics.com/api.aspx (Terms of Use)
- https://github.com/NTag/lyrics.ovh/issues/15
- https://github.com/NTag/lyrics.ovh/issues/17