### PR TITLE
CI: Use 64-bit for Windows and disable autotools build

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -20,31 +20,32 @@ runs:
     - uses: msys2/setup-msys2@v2
       if: startsWith(inputs.os, 'windows')
       with:
-        msystem: MINGW32
+        msystem: MINGW64
         update: true
         install: >-
-          mingw-w64-i686-autotools
-          mingw-w64-i686-faad2
-          mingw-w64-i686-ffmpeg
-          mingw-w64-i686-flac
-          mingw-w64-i686-fluidsynth
-          mingw-w64-i686-gcc
-          mingw-w64-i686-gtk2
-          mingw-w64-i686-json-glib
-          mingw-w64-i686-lame
-          mingw-w64-i686-libbs2b
-          mingw-w64-i686-libcdio-paranoia
-          mingw-w64-i686-libcue
-          mingw-w64-i686-libmodplug
-          mingw-w64-i686-libopenmpt
-          mingw-w64-i686-libsamplerate
-          mingw-w64-i686-libsoxr
-          mingw-w64-i686-libvorbis
-          mingw-w64-i686-meson
-          mingw-w64-i686-mpg123
-          mingw-w64-i686-neon
-          mingw-w64-i686-opusfile
-          mingw-w64-i686-pkg-config
-          mingw-w64-i686-qt5-base
-          mingw-w64-i686-SDL2
-          mingw-w64-i686-wavpack
+          mingw-w64-x86_64-autotools
+          mingw-w64-x86_64-faad2
+          mingw-w64-x86_64-ffmpeg
+          mingw-w64-x86_64-flac
+          mingw-w64-x86_64-fluidsynth
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gtk2
+          mingw-w64-x86_64-json-glib
+          mingw-w64-x86_64-lame
+          mingw-w64-x86_64-libbs2b
+          mingw-w64-x86_64-libcdio-paranoia
+          mingw-w64-x86_64-libcue
+          mingw-w64-x86_64-libmodplug
+          mingw-w64-x86_64-libopenmpt
+          mingw-w64-x86_64-libsamplerate
+          mingw-w64-x86_64-libsidplayfp
+          mingw-w64-x86_64-libsoxr
+          mingw-w64-x86_64-libvorbis
+          mingw-w64-x86_64-meson
+          mingw-w64-x86_64-mpg123
+          mingw-w64-x86_64-neon
+          mingw-w64-x86_64-opusfile
+          mingw-w64-x86_64-pkg-config
+          mingw-w64-x86_64-qt5-base
+          mingw-w64-x86_64-SDL2
+          mingw-w64-x86_64-wavpack

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-12', 'windows-2022']
         build-system: ['autotools', 'meson']
+        exclude:
+          - os: 'windows-2022'
+            build-system: 'autotools'
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
See also: https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages