### PR TITLE
lyrics: Remove French prefix which lyrics.ovh embeds into lyrics

### DIFF
--- a/src/lyrics-common/lyrics_ovh_provider.cc
+++ b/src/lyrics-common/lyrics_ovh_provider.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010-2019 Ariadne Conill <ariadne@dereferenced.org>
+ * Copyright (c) 2024 Thomas Lange <thomas-lange2@gmx.de>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -19,6 +20,21 @@
  */
 
 #include "lyrics.h"
+
+static String truncate_prefix (const String & lyrics, const char * prefix)
+{
+    if (! str_has_prefix_nocase (lyrics, prefix))
+        return lyrics;
+
+    const char * truncated = strstr (lyrics, "\r\n");
+    if (! truncated || ! g_utf8_validate (truncated, -1, nullptr))
+        return lyrics;
+
+    while ((* truncated) && g_unichar_isspace (g_utf8_get_char (truncated)))
+        truncated = g_utf8_next_char (truncated);
+
+    return String (truncated);
+}
 
 bool LyricsOVHProvider::match (LyricsState state)
 {
@@ -51,6 +67,9 @@ void LyricsOVHProvider::fetch (LyricsState state)
             return;
         }
 
+        // Remove French prefix for "Lyrics of the song {title} by {artist}"
+        // which lyrics.ovh embeds into every lyrics, regardless of the language.
+        new_state.lyrics = truncate_prefix (lyrics, "Paroles de la chanson");
         new_state.source = LyricsState::Source::LyricsOVH;
 
         update_lyrics_window (new_state.title, new_state.artist, new_state.lyrics);


### PR DESCRIPTION
https://lyrics.ovh embeds a French prefix for `Lyrics of the song {title} by {artist}` to all lyrics,
regardless of the lyrics language or user country (verified with proxies).

Examples:
- https://api.lyrics.ovh/v1/R.E.M./Shiny%20Happy%20People
- https://api.lyrics.ovh/v1/R.E.M./At%20My%20Most%20Beautiful

Questions:
- Is it safe to return the char pointer like this or should it be wrapped into a String or StringBuf?
- Is there a way to trim also non-breaking-space characters? `g_strchug()` does not remove them.
The 2nd example shows therefore unnecessary newlines below the header.

![grafik](https://github.com/audacious-media-player/audacious-plugins/assets/1301412/cf4721db-d39c-478b-97bb-15b0479d5fc3)