### PR TITLE
meson: Change default Qt version to 6

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -46,6 +46,6 @@ runs:
           mingw-w64-x86_64-neon
           mingw-w64-x86_64-opusfile
           mingw-w64-x86_64-pkg-config
-          mingw-w64-x86_64-qt5-base
+          mingw-w64-x86_64-qt6-base
           mingw-w64-x86_64-SDL2
           mingw-w64-x86_64-wavpack

--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -4,7 +4,7 @@
 #
 # ubuntu-20.04:      Qt 5 + GTK2
 # ubuntu-22.04:      Qt 5 + GTK3
-# Windows:           Qt 5 + GTK2
+# Windows:           Qt 6 + GTK2
 # macOS (Autotools): Qt 5 - GTK
 # macOS (Meson):     Qt 6 - GTK
 

--- a/.github/actions/run-action/run-action.sh
+++ b/.github/actions/run-action/run-action.sh
@@ -4,7 +4,7 @@
 #
 # ubuntu-20.04:      Qt 5 + GTK2
 # ubuntu-22.04:      Qt 5 + GTK3
-# Windows:           Qt 5 + GTK2
+# Windows:           Qt 6 + GTK2
 # macOS (Autotools): Qt 5 - GTK
 # macOS (Meson):     Qt 6 - GTK
 
@@ -24,9 +24,9 @@ fi
 case "$action" in
   configure)
     case "$os" in
-      ubuntu-20.04 | windows*)
+      ubuntu-20.04)
         if [ "$build_system" = 'meson' ]; then
-          meson setup build
+          meson setup build -D qt5=true
         else
           ./autogen.sh && ./configure
         fi
@@ -34,7 +34,7 @@ case "$action" in
 
       ubuntu*)
         if [ "$build_system" = 'meson' ]; then
-          meson setup build -D gtk3=true
+          meson setup build -D qt5=true -D gtk3=true
         else
           ./autogen.sh && ./configure --enable-gtk3
         fi
@@ -42,11 +42,19 @@ case "$action" in
 
       macos*)
         if [ "$build_system" = 'meson' ]; then
-          meson setup build -D qt6=true -D gtk=false -D mac-media-keys=true
+          meson setup build -D gtk=false -D mac-media-keys=true
         else
           export PATH="/usr/local/opt/qt@5/bin:$PATH"
           export PKG_CONFIG_PATH="/usr/local/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
           ./autogen.sh && ./configure --disable-gtk --enable-mac-media-keys
+        fi
+        ;;
+
+      windows*)
+        if [ "$build_system" = 'meson' ]; then
+          meson setup build
+        else
+          ./autogen.sh && ./configure
         fi
         ;;
 

--- a/meson.build
+++ b/meson.build
@@ -64,12 +64,12 @@ x11_dep = dependency('x11', required: false)
 
 
 if get_option('qt')
-  if get_option('qt6')
-    qt_req = '>= 6.0'
-    qt_dep = dependency('qt6', version: qt_req, required: true, modules: ['Core', 'Widgets', 'Gui'])
-  else
+  if get_option('qt5')
     qt_req = '>= 5.2'
     qt_dep = dependency('qt5', version: qt_req, required: true, modules: ['Core', 'Widgets', 'Gui'])
+  else
+    qt_req = '>= 6.0'
+    qt_dep = dependency('qt6', version: qt_req, required: true, modules: ['Core', 'Widgets', 'Gui'])
   endif
 endif
 
@@ -205,8 +205,8 @@ if meson.version().version_compare('>= 0.53')
   }, section: 'Directories')
 
   summary({
-    'Qt 5 support': get_option('qt') and not get_option('qt6'),
-    'Qt 6 support': get_option('qt6'),
+    'Qt 5 support': get_option('qt5'),
+    'Qt 6 support': get_option('qt') and not get_option('qt5'),
     'GTK2 support': get_option('gtk') and not get_option('gtk3'),
     'GTK3 support': get_option('gtk3'),
   }, section: 'GUI Toolkits')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,8 +5,8 @@ option('gtk3', type: 'boolean', value: false,
        description: 'Whether GTK3 support is enabled')
 option('qt', type: 'boolean', value: true,
        description: 'Whether Qt support is enabled')
-option('qt6', type: 'boolean', value: false,
-       description: 'Whether Qt 6 support is enabled')
+option('qt5', type: 'boolean', value: false,
+       description: 'Whether Qt 5 support is enabled')
 
 
 # container plugins

--- a/src/qtaudio/meson.build
+++ b/src/qtaudio/meson.build
@@ -1,12 +1,12 @@
-if get_option('qt6')
+if get_option('qt5')
+  qt_multimedia_dep = dependency('qt5', version: qt_req, required: false, modules: ['Multimedia'])
+else
   qt_multimedia_dep = dependency('qt6', version: qt_req, required: false, modules: ['Multimedia'])
 
   if qt_multimedia_dep.found()
     warning('The Qt Multimedia output plugin is not yet compatible with Qt 6.')
     qt_multimedia_dep = dependency('', required: false)
   endif
-else
-  qt_multimedia_dep = dependency('qt5', version: qt_req, required: false, modules: ['Multimedia'])
 endif
 
 have_qtaudio = qt_multimedia_dep.found()

--- a/src/qtglspectrum/meson.build
+++ b/src/qtglspectrum/meson.build
@@ -1,7 +1,7 @@
-if get_option('qt6')
-  qt_opengl_dep = dependency('qt6', version: qt_req, required: false, modules: ['OpenGL', 'OpenGLWidgets'])
-else
+if get_option('qt5')
   qt_opengl_dep = dependency('qt5', version: '>= 5.4', required: false, modules: ['OpenGL'])
+else
+  qt_opengl_dep = dependency('qt6', version: qt_req, required: false, modules: ['OpenGL', 'OpenGLWidgets'])
 endif
 
 have_qtglspectrum = qt_opengl_dep.found()

--- a/src/qthotkey/meson.build
+++ b/src/qthotkey/meson.build
@@ -1,8 +1,8 @@
-if get_option('qt6')
+if get_option('qt5')
+  qtx11_dep = dependency('qt5', version: qt_req, required: false, modules: ['X11Extras'])
+else
   # QX11Application requires QtGui private headers and Qt >= 6.2
   qtx11_dep = dependency('qt6', version: [qt_req, '>= 6.2'], private_headers: true, required: false, modules: ['Core', 'Gui'])
-else
-  qtx11_dep = dependency('qt5', version: qt_req, required: false, modules: ['X11Extras'])
 endif
 
 have_qthotkey = x11_dep.found() and qtx11_dep.found() and not (have_darwin or have_windows)

--- a/src/streamtuner/meson.build
+++ b/src/streamtuner/meson.build
@@ -1,7 +1,7 @@
-if get_option('qt6')
-  qtnetwork_dep = dependency('qt6', version: qt_req, required: false, modules: ['Network'])
-else
+if get_option('qt5')
   qtnetwork_dep = dependency('qt5', version: qt_req, required: false, modules: ['Network'])
+else
+  qtnetwork_dep = dependency('qt6', version: qt_req, required: false, modules: ['Network'])
 endif
 
 have_streamtuner = qtnetwork_dep.found()


### PR DESCRIPTION
Qt 5 is no longer supported upstream and KDE has migrated as well.
Note that our Autotools build does not support Qt 6.

See also: https://doc.qt.io/qt-6/supported-platforms.html#supported-qt-versions