### PR TITLE
blur_scope-qt: fix incorrect glib.h include path

### DIFF
--- a/src/blur_scope-qt/blur_scope.cc
+++ b/src/blur_scope-qt/blur_scope.cc
@@ -26,7 +26,7 @@
 
 #include <math.h>
 #include <string.h>
-#include <glib-2.0/glib.h>
+#include <glib.h>
 
 #include <QWidget>
 #include <QImage>


### PR DESCRIPTION
The include path given as glib-2.0/glib.h is not correct for meson/pkg-config. This usually works on systems where glib-2.0 is in a system include path, but will break when this is not the case. Changed to match other modules.