### PR TITLE
Made titlebar reflect focus status

### DIFF
--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -1149,9 +1149,13 @@ void MainWindow::draw (cairo_t * cr)
 {
     int width = is_shaded () ? MAINWIN_SHADED_WIDTH : skin.hints.mainwin_width;
     int height = is_shaded () ? MAINWIN_SHADED_HEIGHT : skin.hints.mainwin_height;
-
+    bool focus = has_focus ();
     skin_draw_pixbuf (cr, SKIN_MAIN, 0, 0, 0, 0, width, height);
-    skin_draw_mainwin_titlebar (cr, is_shaded (), true);
+    skin_draw_mainwin_titlebar (cr, is_shaded (), focus);
+    if(focus!=had_focus){
+        had_focus=focus;
+        queue_draw ();
+    }
 }
 
 static void mainwin_create_window ()

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -46,7 +46,7 @@ public:
     void set_shapes (GdkRegion * shape, GdkRegion * sshape);
 #endif
     bool is_shaded () { return m_is_shaded; }
-    bool has_focus() { return gtk_window_has_toplevel_focus (gtk ()) }
+    bool has_focus() { return gtk_window_has_toplevel_focus ((GtkWindow *) gtk ()) }
     void set_shaded (bool shaded);
     void put_widget (bool shaded, Widget * widget, int x, int y);
     void move_widget (bool shaded, Widget * widget, int x, int y);

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -46,6 +46,7 @@ public:
     void set_shapes (GdkRegion * shape, GdkRegion * sshape);
 #endif
     bool is_shaded () { return m_is_shaded; }
+    bool has_focus() { return gtk_window_has_toplevel_focus (gtk ()) }
     void set_shaded (bool shaded);
     void put_widget (bool shaded, Widget * widget, int x, int y);
     void move_widget (bool shaded, Widget * widget, int x, int y);
@@ -67,6 +68,7 @@ protected:
     bool motion (GdkEventMotion * event);
     bool close ();
 
+    bool had_focus=false;
 private:
     void apply_shape ();
 


### PR DESCRIPTION
Made titlebar of main window when using classic skins reflect focus status.

This was bugging me, so I decided to fix it, hopefully I did it on acceptable level.