### PR TITLE
skins: Made titlebar reflect focus status when using classic skins in gtk mode

### DIFF
--- a/src/skins/dock.cc
+++ b/src/skins/dock.cc
@@ -373,3 +373,8 @@ bool dock_is_focused()
     }
     return false;
 }
+
+void refresh_dock_focus(){
+	for (DockWindow & dw : windows)
+        { dw.window -> focus_refresh (); }
+}

--- a/src/skins/dock.cc
+++ b/src/skins/dock.cc
@@ -363,3 +363,13 @@ void dock_change_scale (int old_scale, int new_scale)
         }
     }
 }
+
+bool dock_is_focused()
+{
+    for (DockWindow & dw : windows)
+    {
+    	if (dw.window==nullptr) continue;
+    	if (dw.window->has_focus()) return true;
+    }
+    return false;
+}

--- a/src/skins/equalizer.cc
+++ b/src/skins/equalizer.cc
@@ -255,16 +255,14 @@ void EqWindow::draw (cairo_t * cr)
     int y_off = shaded ? 0 : 134;
     if(!focused) y_off += 15;
     
-    static bool was_focused=false;
-    
     SkinPixmapId tbar_id = shaded ? SKIN_EQ_EX : SKIN_EQMAIN;
-    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 0, 0, 0, 275, shaded ? 14 : 116);//FIXME eq window is not getting focused when you click any other window
+    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 0, 0, 0, 275, shaded ? 14 : 116);
 
     skin_draw_pixbuf (cr, tbar_id, 0, y_off, 0, 0, 275, 14);
 
-    if (was_focused!=focused){
+    if (m_is_drawn_focused!=focused){
     	queue_draw ();
-    	was_focused=focused;
+    	m_is_drawn_focused=focused;
     }
 }
 

--- a/src/skins/equalizer.cc
+++ b/src/skins/equalizer.cc
@@ -250,12 +250,22 @@ static void equalizerwin_create_widgets ()
 
 void EqWindow::draw (cairo_t * cr)
 {
-    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 0, 0, 0, 275, is_shaded () ? 14 : 116);
+    bool shaded = is_shaded ();
+    bool focused = dock_is_focused ();
+    int y_off = shaded ? 0 : 134;
+    if(!focused) y_off += 15;
+    
+    static bool was_focused=false;
+    
+    SkinPixmapId tbar_id = shaded ? SKIN_EQ_EX : SKIN_EQMAIN;
+    skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 0, 0, 0, 275, shaded ? 14 : 116);//FIXME eq window is not getting focused when you click any other window
 
-    if (is_shaded ())
-        skin_draw_pixbuf (cr, SKIN_EQ_EX, 0, 0, 0, 0, 275, 14);
-    else
-        skin_draw_pixbuf (cr, SKIN_EQMAIN, 0, 134, 0, 0, 275, 14);
+    skin_draw_pixbuf (cr, tbar_id, 0, y_off, 0, 0, 275, 14);
+
+    if (was_focused!=focused){
+    	queue_draw ();
+    	was_focused=focused;
+    }
 }
 
 static void equalizerwin_create_window ()

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -1149,7 +1149,7 @@ void MainWindow::draw (cairo_t * cr)
 {
     int width = is_shaded () ? MAINWIN_SHADED_WIDTH : skin.hints.mainwin_width;
     int height = is_shaded () ? MAINWIN_SHADED_HEIGHT : skin.hints.mainwin_height;
-    bool focus = has_focus ();
+    bool focus = dock_is_focused ();
     skin_draw_pixbuf (cr, SKIN_MAIN, 0, 0, 0, 0, width, height);
     skin_draw_mainwin_titlebar (cr, is_shaded (), focus);
     if(focus!=had_focus){

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -1153,7 +1153,6 @@ void MainWindow::draw (cairo_t * cr)
     skin_draw_pixbuf (cr, SKIN_MAIN, 0, 0, 0, 0, width, height);
     skin_draw_mainwin_titlebar (cr, is_shaded (), focus);
     if(focus!=m_is_drawn_focused){
-        queue_draw ();
         m_is_drawn_focused=focus;
     }
 }

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -1152,9 +1152,9 @@ void MainWindow::draw (cairo_t * cr)
     bool focus = dock_is_focused ();
     skin_draw_pixbuf (cr, SKIN_MAIN, 0, 0, 0, 0, width, height);
     skin_draw_mainwin_titlebar (cr, is_shaded (), focus);
-    if(focus!=had_focus){
-        had_focus=focus;
+    if(focus!=m_is_drawn_focused){
         queue_draw ();
+        m_is_drawn_focused=focus;
     }
 }
 

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -1149,9 +1149,13 @@ void MainWindow::draw (cairo_t * cr)
 {
     int width = is_shaded () ? MAINWIN_SHADED_WIDTH : skin.hints.mainwin_width;
     int height = is_shaded () ? MAINWIN_SHADED_HEIGHT : skin.hints.mainwin_height;
-
+    bool focus = has_focus ();
     skin_draw_pixbuf (cr, SKIN_MAIN, 0, 0, 0, 0, width, height);
-    skin_draw_mainwin_titlebar (cr, is_shaded (), true);
+    skin_draw_mainwin_titlebar (cr, is_shaded (), focus);
+    if(focus!=had_focus){
+        had_focus=focus;
+        queue_draw ();
+    }
 }
 
 static void mainwin_create_window ()

--- a/src/skins/playlistwin.cc
+++ b/src/skins/playlistwin.cc
@@ -476,11 +476,16 @@ static void playlistwin_create_widgets ()
 
 void PlWindow::draw (cairo_t * cr)
 {
+    bool focus = dock_is_focused ();
     if (is_shaded ())
-        skin_draw_playlistwin_shaded (cr, config.playlist_width, true);
+        skin_draw_playlistwin_shaded (cr, config.playlist_width, focus);
     else
         skin_draw_playlistwin_frame (cr, config.playlist_width,
-         config.playlist_height, true);
+         config.playlist_height, focus);
+    if (m_is_drawn_focused!=focus){
+    	queue_draw ();
+    	m_is_drawn_focused=focus;
+    }
 }
 
 static void playlistwin_create_window ()

--- a/src/skins/window.cc
+++ b/src/skins/window.cc
@@ -83,6 +83,18 @@ Window::~Window ()
 
     g_object_unref (m_normal);
     g_object_unref (m_shaded);
+    
+}
+
+static void focus_cb(GtkWidget *widget , GdkEventFocus *event , Window * win_ptr ){
+	win_ptr->focus_set(!! event->in);
+	refresh_dock_focus();
+}
+void Window::focus_refresh(){
+	
+	if (m_is_drawn_focused==dock_is_focused()) return;
+	queue_draw();
+	m_is_drawn_focused=dock_is_focused();
 }
 
 Window::Window (int id, int * x, int * y, int w, int h, bool shaded) :
@@ -136,6 +148,9 @@ Window::Window (int id, int * x, int * y, int w, int h, bool shaded) :
         gtk_container_add ((GtkContainer *) window, m_normal);
 
     dock_add_window (id, this, x, y, w, h);
+    
+    focus_hook_id1=g_signal_connect(G_OBJECT(window), "focus-out-event", G_CALLBACK(focus_cb), this);
+    focus_hook_id2=g_signal_connect(G_OBJECT(window), "focus-in-event", G_CALLBACK(focus_cb), this);
 }
 
 void Window::resize (int w, int h)

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -46,7 +46,7 @@ public:
     void set_shapes (GdkRegion * shape, GdkRegion * sshape);
 #endif
     bool is_shaded () { return m_is_shaded; }
-    bool has_focus() { return gtk_window_has_toplevel_focus (gtk ()) }
+    bool has_focus() { return gtk_window_has_toplevel_focus ((GtkWindow *) gtk ()) }
     void set_shaded (bool shaded);
     void put_widget (bool shaded, Widget * widget, int x, int y);
     void move_widget (bool shaded, Widget * widget, int x, int y);

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -46,7 +46,7 @@ public:
     void set_shapes (GdkRegion * shape, GdkRegion * sshape);
 #endif
     bool is_shaded () { return m_is_shaded; }
-    bool has_focus() { return gtk_window_has_toplevel_focus ((GtkWindow *) gtk ()) }
+    bool has_focus() { return gtk_window_has_toplevel_focus ((GtkWindow *) gtk ()) ;}
     void set_shaded (bool shaded);
     void put_widget (bool shaded, Widget * widget, int x, int y);
     void move_widget (bool shaded, Widget * widget, int x, int y);

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -46,6 +46,7 @@ public:
     void set_shapes (GdkRegion * shape, GdkRegion * sshape);
 #endif
     bool is_shaded () { return m_is_shaded; }
+    bool has_focus() { return gtk_window_has_toplevel_focus (gtk ()) }
     void set_shaded (bool shaded);
     void put_widget (bool shaded, Widget * widget, int x, int y);
     void move_widget (bool shaded, Widget * widget, int x, int y);
@@ -67,6 +68,7 @@ protected:
     bool motion (GdkEventMotion * event);
     bool close ();
 
+    bool had_focus=false;
 private:
     void apply_shape ();
 

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -46,7 +46,9 @@ public:
     void set_shapes (GdkRegion * shape, GdkRegion * sshape);
 #endif
     bool is_shaded () { return m_is_shaded; }
-    bool has_focus() { return gtk_window_has_toplevel_focus ((GtkWindow *) gtk ()) ;}
+    bool has_focus () { return m_is_focused;}
+    void focus_refresh();
+    void focus_set (bool focus) {m_is_focused=focus;}
     void set_shaded (bool shaded);
     void put_widget (bool shaded, Widget * widget, int x, int y);
     void move_widget (bool shaded, Widget * widget, int x, int y);
@@ -67,14 +69,15 @@ protected:
     bool button_release (GdkEventButton * event);
     bool motion (GdkEventMotion * event);
     bool close ();
-
-    bool had_focus=false;
 private:
     void apply_shape ();
 
+    long focus_hook_id1, focus_hook_id2;
     const int m_id;
     bool m_is_shaded = false;
     bool m_is_moving = false;
+    bool m_is_focused = false;
+    bool m_is_drawn_focused = false;
     GtkWidget * m_normal = nullptr, * m_shaded = nullptr;
 #ifdef USE_GTK3
     SmartPtr<cairo_region_t, cairo_region_destroy> m_shape, m_sshape;
@@ -90,5 +93,6 @@ void dock_move_start (int id, int x, int y);
 void dock_move (int x, int y);
 void dock_change_scale (int old_scale, int new_scale);
 bool dock_is_focused ();
+void refresh_dock_focus();
 
 #endif

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -69,6 +69,7 @@ protected:
     bool button_release (GdkEventButton * event);
     bool motion (GdkEventMotion * event);
     bool close ();
+    bool m_is_drawn_focused = false;
 private:
     void apply_shape ();
 
@@ -77,7 +78,6 @@ private:
     bool m_is_shaded = false;
     bool m_is_moving = false;
     bool m_is_focused = false;
-    bool m_is_drawn_focused = false;
     GtkWidget * m_normal = nullptr, * m_shaded = nullptr;
 #ifdef USE_GTK3
     SmartPtr<cairo_region_t, cairo_region_destroy> m_shape, m_sshape;

--- a/src/skins/window.h
+++ b/src/skins/window.h
@@ -89,5 +89,6 @@ void dock_set_size (int id, int w, int h);
 void dock_move_start (int id, int x, int y);
 void dock_move (int x, int y);
 void dock_change_scale (int old_scale, int new_scale);
+bool dock_is_focused ();
 
 #endif


### PR DESCRIPTION
This is a rework of merge request [#158 ](y0shir:master)
This makes main, equalizer and playlist window all use focused versions of titlebars when focus in on either of them and unfocused when none of them have focus.