### PR TITLE
skins and skins-qt: Improved Winamp Skins support

### DIFF
--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -135,10 +135,19 @@ static void mainwin_position_motion_cb ();
 static void mainwin_position_release_cb ();
 static void seek_timeout (void * rewind);
 
+bool change_vis_type(QMouseEvent *event) {
+    config.vis_type = (config.vis_type + 1) % 4;
+    if (config.vis_type == VIS_OFF){
+        mainwin_vis->clear ();
+        mainwin_svis->clear ();
+    }
+    return true;
+}
+
 /* always returns a 6-character string */
 static StringBuf format_time (int time, int length)
 {
-    bool zero = aud_get_bool ("leading_zero");
+    //bool zero = aud_get_bool ("leading_zero");
     bool remaining = aud_get_bool ("skins", "show_remaining_time");
 
     if (remaining && length > 0)
@@ -147,9 +156,9 @@ static StringBuf format_time (int time, int length)
         time = aud::clamp(0, time, 359999); // 99:59:59
 
         if (time < 60)
-            return str_printf (zero ? "-00:%02d" : " -0:%02d", time);
+            return str_printf ("-00:%02d", time);
         else if (time < 6000)
-            return str_printf (zero ? "%03d:%02d" : "%3d:%02d", -time / 60, time % 60);
+            return str_printf ("%03d:%02d", -time / 60, time % 60);
         else
             return str_printf ("%3d:%02d", -time / 3600, time / 60 % 60);
     }
@@ -159,7 +168,7 @@ static StringBuf format_time (int time, int length)
         time = aud::clamp(0, time, 3599999); // 999:59:59
 
         if (time < 6000)
-            return str_printf (zero ? " %02d:%02d" : " %2d:%02d", time / 60, time % 60);
+            return str_printf (" %02d:%02d", time / 60, time % 60);
         else if (time < 60000)
             return str_printf ("%3d:%02d", time / 60, time % 60);
         else
@@ -828,18 +837,22 @@ void mainwin_mr_change (MenuRowItem i)
             break;
         case MENUROW_ALWAYS:
             if (aud_get_bool ("skins", "always_on_top"))
-                mainwin_lock_info_text (_("Disable 'Always On Top'"));
+                mainwin_lock_info_text (_("Disable Always-On-Top"));
             else
-                mainwin_lock_info_text (_("Enable 'Always On Top'"));
+                mainwin_lock_info_text (_("Enable Always-On-Top"));
             break;
         case MENUROW_FILEINFOBOX:
             mainwin_lock_info_text (_("File Info Box"));
             break;
         case MENUROW_SCALE:
-            mainwin_lock_info_text (_("Double Size"));
+            if (config.scale == 1){
+                mainwin_lock_info_text (_("Enable Doublesize Mode"));
+            } else {
+                mainwin_lock_info_text (_("Disable Doublesize Mode"));
+            }
             break;
         case MENUROW_VISUALIZATION:
-            mainwin_lock_info_text (_("Visualizations"));
+            mainwin_lock_info_text (_("Visualization Window"));
             break;
         default:
             break;
@@ -1023,6 +1036,7 @@ static void mainwin_create_widgets ()
 
     mainwin_vis = new SkinnedVis;
     mainwin->put_widget (false, mainwin_vis, 24, 43);
+    mainwin_vis->on_press (change_vis_type);
 
     mainwin_position = new HSlider (0, 219, SKIN_POSBAR, 248, 10, 0, 0, 29, 10, 248, 0, 278, 0);
     mainwin->put_widget (false, mainwin_position, 16, 72);
@@ -1073,6 +1087,7 @@ static void mainwin_create_widgets ()
 
     mainwin_svis = new SmallVis ();
     mainwin->put_widget (true, mainwin_svis, 79, 5);
+    mainwin_svis->on_press (change_vis_type);
 
     mainwin_sposition = new HSlider (1, 13, SKIN_TITLEBAR, 17, 7, 0, 36, 3, 7, 17, 36, 17, 36);
     mainwin->put_widget (true, mainwin_sposition, 226, 4);
@@ -1080,7 +1095,7 @@ static void mainwin_create_widgets ()
     mainwin_sposition->on_release (mainwin_spos_release_cb);
 
     mainwin_stime_min = new TextBox (15, nullptr, false);
-    mainwin->put_widget (true, mainwin_stime_min, 130, 4);
+    mainwin->put_widget (true, mainwin_stime_min, 129, 4);
     mainwin_stime_min->on_press (change_timer_mode_cb);
 
     mainwin_stime_sec = new TextBox (10, nullptr, false);

--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -414,7 +414,7 @@ static void mainwin_playback_stop ()
     seeking = false;
     timer_remove (TimerRate::Hz10, seek_timeout);
 
-    mainwin_set_song_title (nullptr);
+    //mainwin_set_song_title (nullptr);
 
     mainwin_vis->clear ();
     mainwin_svis->clear ();
@@ -1187,7 +1187,7 @@ void mainwin_create ()
 {
     mainwin_create_window ();
     mainwin_create_widgets ();
-    mainwin_set_song_title (nullptr);
+    //mainwin_set_song_title (nullptr);
 }
 
 static void mainwin_update_volume ()

--- a/src/skins-qt/menurow.cc
+++ b/src/skins-qt/menurow.cc
@@ -35,23 +35,21 @@
 
 void MenuRow::draw (QPainter & cr)
 {
-    if (m_selected == MENUROW_NONE)
-    {
-        if (m_pushed)
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304, 0, 0, 0, 8, 43);
-        else
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 0, 0, 0, 8, 43);
-    }
-    else
-        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304 + 8 * (m_selected - 1), 44, 0, 0, 8, 43);
-
     if (m_pushed)
-    {
-        if (aud_get_bool ("skins", "always_on_top"))
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 54, 0, 10, 8, 8);
-        if (aud_get_bool ("skins", "double_size"))
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 328, 70, 0, 26, 8, 8);
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304, 0, 0, 0, 8, 43);
+    else
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 0, 0, 0, 8, 43);
+
+    if (!m_selected){
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304, 0, 0, 0, 8, 43);
+    } else {
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304 + 8 * (m_selected - 1), 44, 0, 0, 8, 43);
     }
+
+    if (aud_get_bool ("skins", "always_on_top"))
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 54, 0, 10, 8, 8);
+    if (aud_get_bool ("skins", "double_size"))
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 328, 70, 0, 26, 8, 8);
 }
 
 static MenuRowItem menurow_find_selected (int x, int y)

--- a/src/skins-qt/skin.h
+++ b/src/skins-qt/skin.h
@@ -75,9 +75,9 @@ struct SkinHints {
     int mainwin_vis_visible = true;
 
     /* Text properties */
-    int mainwin_text_x = 112;
+    int mainwin_text_x = 111;
     int mainwin_text_y = 27;
-    int mainwin_text_width = 153;
+    int mainwin_text_width = 154;
     int mainwin_text_visible = true;
 
     /* Infobar properties */

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -31,15 +31,22 @@
 #include "skin.h"
 #include "vis.h"
 
-static const int svis_analyzer_colors[] = {14, 11, 8, 5, 2};
+static const float vis_afalloff_speeds[] = {0.19, 0.422, 0.75, 1.0, 2.0};
+static const float vis_pfalloff_speeds[] = {1.1, 1.15, 1.25, 1.4, 1.75};
+static const int svis_analyzer_colors[] = {17, 14, 11, 8, 5};
 static const int svis_scope_colors[] = {20, 19, 18, 19, 20};
-static const int svis_vu_normal_colors[] = {16, 14, 12, 10, 8, 6, 4, 2};
+static const int svis_vu_normal_colors[] = {17, 17, 17, 13, 13, 13, 2, 2};
 
 #define RGB_SEEK(x,y) (set = rgb + 38 * (y) + (x))
 #define RGB_SET(c) (* set ++ = (c))
 #define RGB_SET_Y(c) do {* set = (c); set += 38;} while (0)
 #define RGB_SET_INDEX(c) RGB_SET (skin.vis_colors[c])
 #define RGB_SET_INDEX_Y(c) RGB_SET_Y (skin.vis_colors[c])
+
+bool SmallVis::button_press (QMouseEvent * event)
+{
+    return press ? press (event) : false;
+}
 
 void SmallVis::draw (QPainter & cr)
 {
@@ -56,17 +63,30 @@ void SmallVis::draw (QPainter & cr)
     {
         bool bars = (config.analyzer_type == ANALYZER_BARS);
 
-        for (int x = 0; x < 38; x ++)
+        for (int x = 0; x < 37; x ++)
         {
-            if (bars && (x % 3) == 2)
+            if (bars && (x % 4) == 3)
                 continue;
 
-            int h = m_data[bars ? (x / 3) : x];
+            int h = m_datafalloff[bars ? (x / 4) : x];
             h = aud::clamp (h, 0, 5);
             RGB_SEEK (x, 5 - h);
 
             for (int y = 0; y < h; y ++)
                 RGB_SET_INDEX_Y (svis_analyzer_colors[h - 1 - y]);
+
+        if (config.analyzer_peaks)
+            {
+                int h;
+                h = m_truepeaks[bars ? (x / 4) : x];
+                h = aud::clamp (h, 0, 16);
+
+                if (h)
+                {
+                    RGB_SEEK (x, 5 - h);
+                    RGB_SET_INDEX (23);
+                }
+            }
         }
 
         break;
@@ -122,35 +142,42 @@ void SmallVis::draw (QPainter & cr)
         case SCOPE_DOT:
             for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
+                int h = scale[aud::clamp ((int)m_data[x], 0, 16)];
                 RGB_SEEK (x, h);
-                RGB_SET_INDEX (svis_scope_colors[h]);
+                RGB_SET_INDEX (svis_scope_colors[2]);
             }
             break;
         case SCOPE_LINE:
         {
-            for (int x = 0; x < 37; x ++)
+            for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
-                int h2 = scale[aud::clamp (m_data[2 * (x + 1)], 0, 16)];
+                int h = scale[aud::clamp ((int)m_data[x], 0, 16)];
 
-                if (h < h2) h2 --;
-                else if (h > h2) {int temp = h; h = h2 + 1; h2 = temp;}
+                    if (x == 0) {
+                        last_h = h;
+                    }
 
-                RGB_SEEK (x, h);
-                for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    top = h;
+                    bottom = last_h;
+                    last_h = h;
+
+                    if (bottom < top) {
+                        int temp = bottom;
+                        bottom = top;
+                        top = temp;
+                    }
+
+                for (int y = top; y <= bottom; y ++){
+                    RGB_SEEK (x, y);
+                    RGB_SET_INDEX_Y (svis_scope_colors[2]);
+                }
             }
-
-            int h = scale[aud::clamp (m_data[74], 0, 16)];
-            RGB_SEEK (37, h);
-            RGB_SET_INDEX (svis_scope_colors[h]);
             break;
         }
         default: /* SCOPE_SOLID */
             for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
+                int h = scale[aud::clamp ((int)m_data[x], 0, 16)];
                 int h2;
 
                 if (h < 2)
@@ -163,12 +190,12 @@ void SmallVis::draw (QPainter & cr)
 
                 RGB_SEEK (x, h);
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (svis_scope_colors[2]);
             }
             break;
         }
         break;
-    }
+        }
     }
 
 DRAW:
@@ -186,13 +213,39 @@ SmallVis::SmallVis ()
 void SmallVis::clear ()
 {
     m_active = false;
+    memset (m_datafalloff, 0, sizeof m_datafalloff);
+    memset (m_truepeaks, 0, sizeof m_truepeaks);
     memset (m_data, 0, sizeof m_data);
     queue_draw ();
 }
 
 void SmallVis::render (const unsigned char * data)
 {
-    if (config.vis_type == VIS_VOICEPRINT)
+    if (config.vis_type == VIS_ANALYZER)
+    {
+    const int n = (config.analyzer_type == ANALYZER_BARS) ? 10 : 38;
+        for (int i = 0; i < n; i ++)
+        {
+            m_data[i] = data[i];
+            m_data[i] = aud::clamp(static_cast<int>(m_data[i]), 0, 5);
+            m_datafalloff[i] -= (vis_afalloff_speeds[config.analyzer_falloff]) * 2;
+
+            if (m_datafalloff[i] <= m_data[i]) {
+                m_datafalloff[i] = m_data[i];
+            }
+
+            if (m_peak[i] <= (int)((m_datafalloff[i] + 1) * 256)){
+                m_peak[i] = (int)((m_datafalloff[i] + 1) * 256);
+                m_data2[i] = 3.0f;
+            }
+
+            m_truepeaks[i] = m_peak[i]/256;
+
+            m_peak[i] -= (int)m_data2[i];
+            m_data2[i] *= (vis_pfalloff_speeds[config.peaks_falloff]);
+        }
+    }
+    else if (config.vis_type == VIS_VOICEPRINT)
     {
         for (int i = 0; i < 2; i ++)
             m_data[i] = data[i];

--- a/src/skins-qt/textbox.cc
+++ b/src/skins-qt/textbox.cc
@@ -213,7 +213,7 @@ void TextBox::render ()
 
         if (! m_two_way)
         {
-            StringBuf temp = str_printf ("%s --- ", text);
+            StringBuf temp = str_printf ("%s *** ", text);
 
             if (m_font)
                 render_vector (temp);

--- a/src/skins-qt/vis-callbacks.cc
+++ b/src/skins-qt/vis-callbacks.cc
@@ -52,8 +52,8 @@ public:
 
 void VisCallbacks::clear ()
 {
-    mainwin_vis->clear ();
-    mainwin_svis->clear ();
+    /*mainwin_vis->clear ();
+    mainwin_svis->clear ();*/
 }
 
 void VisCallbacks::render_mono_pcm (const float * pcm)
@@ -120,6 +120,8 @@ static void make_log_graph (const float * freq, int bands, int db_range,
     static int last_bands = 0;
     static Index<float> xscale;
 
+    bool shaded = aud_get_bool ("skins", "player_shaded");
+
     /* conversion table for the x-axis */
     if (bands != last_bands)
     {
@@ -133,6 +135,17 @@ static void make_log_graph (const float * freq, int bands, int db_range,
         float val = Visualizer::compute_freq_band (freq, & xscale[0], i, bands);
         /* scale (-db_range, 0.0) to (0.0, int_range) */
         val = (1 + val / db_range) * int_range;
+        if (config.vis_type == VIS_VOICEPRINT){
+            // do nothing
+        }
+        else {
+            if (shaded){
+                val = std::pow(10, val / 10.0) * 1.25;
+            } else {
+                val = std::pow(10, val / 10.0) / 1.6;
+            }
+
+        }
         graph[i] = aud::clamp ((int) val, 0, int_range);
     }
 }
@@ -148,7 +161,7 @@ void VisCallbacks::render_freq (const float * freq)
         if (config.analyzer_type == ANALYZER_BARS)
         {
             if (shaded)
-                make_log_graph (freq, 13, 40, 8, data);
+                make_log_graph (freq, 10, 40, 8, data);
             else
                 make_log_graph (freq, 19, 40, 16, data);
         }

--- a/src/skins-qt/vis.h
+++ b/src/skins-qt/vis.h
@@ -59,9 +59,12 @@ public:
     void set_colors ();
     void clear ();
     void render (const unsigned char * data);
+    typedef bool (* PressCB) (QMouseEvent *);
+    void on_press (PressCB callback) { press = callback; }
 
 private:
     void draw (QPainter & cr);
+    virtual bool button_press (QMouseEvent * event);
 
     uint32_t m_voice_color[256];
     uint32_t m_voice_color_fire[256];
@@ -69,8 +72,15 @@ private:
     uint32_t m_pattern_fill[76 * 2];
 
     bool m_active, m_voiceprint_advance;
-    float m_data[75], m_peak[75], m_peak_speed[75];
+    float m_data[75] = {0};
+    float m_peak[75] = {0};
+    float m_data2[75] = {0};
+    float m_datafalloff[75] = {0};
+    float m_data4[75] = {0};
+    float m_truepeaks[75] = {0};
+    int top, bottom, last_h;
     unsigned char m_voiceprint_data[76 * 16];
+    PressCB press = nullptr;
 };
 
 class SmallVis : public Widget
@@ -79,12 +89,22 @@ public:
     SmallVis ();
     void clear ();
     void render (const unsigned char * data);
+    typedef bool (* PressCB) (QMouseEvent *);
+    void on_press (PressCB callback) { press = callback; }
 
 private:
     void draw (QPainter & cr);
+    virtual bool button_press (QMouseEvent * event);
 
     bool m_active;
-    int m_data[75];
+    float m_data[75] = {0};
+    float m_peak[75] = {0};
+    float m_data2[75] = {0};
+    float m_datafalloff[75] = {0};
+    float m_data4[75] = {0};
+    float m_truepeaks[75] = {0};
+    int top, bottom, last_h;
+    PressCB press = nullptr;
 };
 
 #endif

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -131,10 +131,19 @@ static void mainwin_position_motion_cb ();
 static void mainwin_position_release_cb ();
 static void seek_timeout (void * rewind);
 
+bool change_vis_type(GdkEventButton * event) {
+    config.vis_type = (config.vis_type + 1) % 4;
+    if (config.vis_type == VIS_OFF){
+        mainwin_vis->clear ();
+        mainwin_svis->clear ();
+    }
+    return true;
+}
+
 /* always returns a 6-character string */
 static StringBuf format_time (int time, int length)
 {
-    bool zero = aud_get_bool ("leading_zero");
+    //bool zero = aud_get_bool ("leading_zero");
     bool remaining = aud_get_bool ("skins", "show_remaining_time");
 
     if (remaining && length > 0)
@@ -143,9 +152,9 @@ static StringBuf format_time (int time, int length)
         time = aud::clamp(0, time, 359999); // 99:59:59
 
         if (time < 60)
-            return str_printf (zero ? "-00:%02d" : " -0:%02d", time);
+            return str_printf ("-00:%02d", time);
         else if (time < 6000)
-            return str_printf (zero ? "%03d:%02d" : "%3d:%02d", -time / 60, time % 60);
+            return str_printf ("%03d:%02d", -time / 60, time % 60);
         else
             return str_printf ("%3d:%02d", -time / 3600, time / 60 % 60);
     }
@@ -155,7 +164,7 @@ static StringBuf format_time (int time, int length)
         time = aud::clamp(0, time, 3599999); // 999:59:59
 
         if (time < 6000)
-            return str_printf (zero ? " %02d:%02d" : " %2d:%02d", time / 60, time % 60);
+            return str_printf (" %02d:%02d", time / 60, time % 60);
         else if (time < 60000)
             return str_printf ("%3d:%02d", time / 60, time % 60);
         else
@@ -874,18 +883,22 @@ void mainwin_mr_change (MenuRowItem i)
             break;
         case MENUROW_ALWAYS:
             if (aud_get_bool ("skins", "always_on_top"))
-                mainwin_lock_info_text (_("Disable 'Always On Top'"));
+                mainwin_lock_info_text (_("Disable Always-On-Top"));
             else
-                mainwin_lock_info_text (_("Enable 'Always On Top'"));
+                mainwin_lock_info_text (_("Enable Always-On-Top"));
             break;
         case MENUROW_FILEINFOBOX:
             mainwin_lock_info_text (_("File Info Box"));
             break;
         case MENUROW_SCALE:
-            mainwin_lock_info_text (_("Double Size"));
+            if (config.scale == 1){
+                mainwin_lock_info_text (_("Enable Doublesize Mode"));
+            } else {
+                mainwin_lock_info_text (_("Disable Doublesize Mode"));
+            }
             break;
         case MENUROW_VISUALIZATION:
-            mainwin_lock_info_text (_("Visualizations"));
+            mainwin_lock_info_text (_("Visualization Window"));
             break;
         default:
             break;
@@ -1069,6 +1082,7 @@ static void mainwin_create_widgets ()
 
     mainwin_vis = new SkinnedVis;
     mainwin->put_widget (false, mainwin_vis, 24, 43);
+    mainwin_vis->on_press (change_vis_type);
 
     mainwin_position = new HSlider (0, 219, SKIN_POSBAR, 248, 10, 0, 0, 29, 10, 248, 0, 278, 0);
     mainwin->put_widget (false, mainwin_position, 16, 72);
@@ -1119,6 +1133,7 @@ static void mainwin_create_widgets ()
 
     mainwin_svis = new SmallVis ();
     mainwin->put_widget (true, mainwin_svis, 79, 5);
+    mainwin_svis->on_press (change_vis_type);
 
     mainwin_sposition = new HSlider (1, 13, SKIN_TITLEBAR, 17, 7, 0, 36, 3, 7, 17, 36, 17, 36);
     mainwin->put_widget (true, mainwin_sposition, 226, 4);

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -424,7 +424,7 @@ static void mainwin_playback_stop ()
     seeking = false;
     timer_remove (TimerRate::Hz10, seek_timeout);
 
-    mainwin_set_song_title (nullptr);
+    //mainwin_set_song_title (nullptr);
 
     mainwin_vis->clear ();
     mainwin_svis->clear ();
@@ -1229,7 +1229,7 @@ void mainwin_create ()
 {
     mainwin_create_window ();
     mainwin_create_widgets ();
-    mainwin_set_song_title (nullptr);
+    //mainwin_set_song_title (nullptr);
 }
 
 static void mainwin_update_volume ()

--- a/src/skins/menurow.cc
+++ b/src/skins/menurow.cc
@@ -33,23 +33,21 @@
 
 void MenuRow::draw (cairo_t * cr)
 {
-    if (m_selected == MENUROW_NONE)
-    {
-        if (m_pushed)
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304, 0, 0, 0, 8, 43);
-        else
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 0, 0, 0, 8, 43);
-    }
-    else
-        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304 + 8 * (m_selected - 1), 44, 0, 0, 8, 43);
-
     if (m_pushed)
-    {
-        if (aud_get_bool ("skins", "always_on_top"))
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 54, 0, 10, 8, 8);
-        if (aud_get_bool ("skins", "double_size"))
-            skin_draw_pixbuf (cr, SKIN_TITLEBAR, 328, 70, 0, 26, 8, 8);
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304, 0, 0, 0, 8, 43);
+    else
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 0, 0, 0, 8, 43);
+
+    if (!m_selected){
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304, 0, 0, 0, 8, 43);
+    } else {
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 304 + 8 * (m_selected - 1), 44, 0, 0, 8, 43);
     }
+
+    if (aud_get_bool ("skins", "always_on_top"))
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 312, 54, 0, 10, 8, 8);
+    if (aud_get_bool ("skins", "double_size"))
+        skin_draw_pixbuf (cr, SKIN_TITLEBAR, 328, 70, 0, 26, 8, 8);
 }
 
 static MenuRowItem menurow_find_selected (int x, int y)

--- a/src/skins/skin.h
+++ b/src/skins/skin.h
@@ -83,9 +83,9 @@ struct SkinHints {
     int mainwin_vis_visible = true;
 
     /* Text properties */
-    int mainwin_text_x = 112;
+    int mainwin_text_x = 111;
     int mainwin_text_y = 27;
-    int mainwin_text_width = 153;
+    int mainwin_text_width = 154;
     int mainwin_text_visible = true;
 
     /* Infobar properties */

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -32,15 +32,22 @@
 #include "skin.h"
 #include "vis.h"
 
-static const int svis_analyzer_colors[] = {14, 11, 8, 5, 2};
+static const float vis_afalloff_speeds[] = {0.19, 0.422, 0.75, 1.0, 2.0};
+static const float vis_pfalloff_speeds[] = {1.1, 1.15, 1.25, 1.4, 1.75};
+static const int svis_analyzer_colors[] = {17, 14, 11, 8, 5};
 static const int svis_scope_colors[] = {20, 19, 18, 19, 20};
-static const int svis_vu_normal_colors[] = {16, 14, 12, 10, 8, 6, 4, 2};
+static const int svis_vu_normal_colors[] = {17, 17, 17, 13, 13, 13, 2, 2};
 
 #define RGB_SEEK(x,y) (set = rgb + 38 * (y) + (x))
 #define RGB_SET(c) (* set ++ = (c))
 #define RGB_SET_Y(c) do {* set = (c); set += 38;} while (0)
 #define RGB_SET_INDEX(c) RGB_SET (skin.vis_colors[c])
 #define RGB_SET_INDEX_Y(c) RGB_SET_Y (skin.vis_colors[c])
+
+bool SmallVis::button_press (GdkEventButton * event)
+{
+    return press ? press (event) : false;
+}
 
 void SmallVis::draw (cairo_t * cr)
 {
@@ -57,17 +64,30 @@ void SmallVis::draw (cairo_t * cr)
     {
         bool bars = (config.analyzer_type == ANALYZER_BARS);
 
-        for (int x = 0; x < 38; x ++)
+        for (int x = 0; x < 37; x ++)
         {
-            if (bars && (x % 3) == 2)
+            if (bars && (x % 4) == 3)
                 continue;
 
-            int h = m_data[bars ? (x / 3) : x];
+            int h = m_datafalloff[bars ? (x / 4) : x];
             h = aud::clamp (h, 0, 5);
             RGB_SEEK (x, 5 - h);
 
             for (int y = 0; y < h; y ++)
                 RGB_SET_INDEX_Y (svis_analyzer_colors[h - 1 - y]);
+
+        if (config.analyzer_peaks)
+            {
+                int h;
+                h = m_truepeaks[bars ? (x / 4) : x];
+                h = aud::clamp (h, 0, 16);
+
+                if (h)
+                {
+                    RGB_SEEK (x, 5 - h);
+                    RGB_SET_INDEX (23);
+                }
+            }
         }
 
         break;
@@ -123,35 +143,42 @@ void SmallVis::draw (cairo_t * cr)
         case SCOPE_DOT:
             for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
+                int h = scale[aud::clamp ((int)m_data[x], 0, 16)];
                 RGB_SEEK (x, h);
-                RGB_SET_INDEX (svis_scope_colors[h]);
+                RGB_SET_INDEX (svis_scope_colors[2]);
             }
             break;
         case SCOPE_LINE:
         {
-            for (int x = 0; x < 37; x ++)
+            for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
-                int h2 = scale[aud::clamp (m_data[2 * (x + 1)], 0, 16)];
+                int h = scale[aud::clamp ((int)m_data[x], 0, 16)];
 
-                if (h < h2) h2 --;
-                else if (h > h2) {int temp = h; h = h2 + 1; h2 = temp;}
+                    if (x == 0) {
+                        last_h = h;
+                    }
 
-                RGB_SEEK (x, h);
-                for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    top = h;
+                    bottom = last_h;
+                    last_h = h;
+
+                    if (bottom < top) {
+                        int temp = bottom;
+                        bottom = top;
+                        top = temp;
+                    }
+
+                for (int y = top; y <= bottom; y ++){
+                    RGB_SEEK (x, y);
+                    RGB_SET_INDEX_Y (svis_scope_colors[2]);
+                }
             }
-
-            int h = scale[aud::clamp (m_data[74], 0, 16)];
-            RGB_SEEK (37, h);
-            RGB_SET_INDEX (svis_scope_colors[h]);
             break;
         }
         default: /* SCOPE_SOLID */
             for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
+                int h = scale[aud::clamp ((int)m_data[x], 0, 16)];
                 int h2;
 
                 if (h < 2)
@@ -164,12 +191,12 @@ void SmallVis::draw (cairo_t * cr)
 
                 RGB_SEEK (x, h);
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (svis_scope_colors[2]);
             }
             break;
         }
         break;
-    }
+        }
     }
 
 DRAW:
@@ -191,13 +218,39 @@ SmallVis::SmallVis ()
 void SmallVis::clear ()
 {
     m_active = false;
+    memset (m_datafalloff, 0, sizeof m_datafalloff);
+    memset (m_truepeaks, 0, sizeof m_truepeaks);
     memset (m_data, 0, sizeof m_data);
     queue_draw ();
 }
 
 void SmallVis::render (const unsigned char * data)
 {
-    if (config.vis_type == VIS_VOICEPRINT)
+    if (config.vis_type == VIS_ANALYZER)
+    {
+    const int n = (config.analyzer_type == ANALYZER_BARS) ? 10 : 38;
+        for (int i = 0; i < n; i ++)
+        {
+            m_data[i] = data[i];
+            m_data[i] = aud::clamp(static_cast<int>(m_data[i]), 0, 5);
+            m_datafalloff[i] -= (vis_afalloff_speeds[config.analyzer_falloff]) * 2;
+
+            if (m_datafalloff[i] <= m_data[i]) {
+                m_datafalloff[i] = m_data[i];
+            }
+
+            if (m_peak[i] <= (int)((m_datafalloff[i] + 1) * 256)){
+                m_peak[i] = (int)((m_datafalloff[i] + 1) * 256);
+                m_data2[i] = 3.0f;
+            }
+
+            m_truepeaks[i] = m_peak[i]/256;
+
+            m_peak[i] -= (int)m_data2[i];
+            m_data2[i] *= (vis_pfalloff_speeds[config.peaks_falloff]);
+        }
+    }
+    else if (config.vis_type == VIS_VOICEPRINT)
     {
         for (int i = 0; i < 2; i ++)
             m_data[i] = data[i];

--- a/src/skins/textbox.cc
+++ b/src/skins/textbox.cc
@@ -230,7 +230,7 @@ void TextBox::render ()
 
         if (! m_two_way)
         {
-            StringBuf temp = str_printf ("%s --- ", text);
+            StringBuf temp = str_printf ("%s *** ", text);
 
             if (m_font)
                 render_vector (temp);

--- a/src/skins/vis-callbacks.cc
+++ b/src/skins/vis-callbacks.cc
@@ -52,8 +52,8 @@ public:
 
 void VisCallbacks::clear ()
 {
-    mainwin_vis->clear ();
-    mainwin_svis->clear ();
+    /*mainwin_vis->clear ();
+    mainwin_svis->clear ();*/
 }
 
 void VisCallbacks::render_mono_pcm (const float * pcm)
@@ -120,6 +120,8 @@ static void make_log_graph (const float * freq, int bands, int db_range,
     static int last_bands = 0;
     static Index<float> xscale;
 
+    bool shaded = aud_get_bool ("skins", "player_shaded");
+
     /* conversion table for the x-axis */
     if (bands != last_bands)
     {
@@ -133,6 +135,17 @@ static void make_log_graph (const float * freq, int bands, int db_range,
         float val = Visualizer::compute_freq_band (freq, & xscale[0], i, bands);
         /* scale (-db_range, 0.0) to (0.0, int_range) */
         val = (1 + val / db_range) * int_range;
+        if (config.vis_type == VIS_VOICEPRINT){
+            // do nothing
+        }
+        else {
+            if (shaded){
+                val = std::pow(10, val / 10.0) * 1.25;
+            } else {
+                val = std::pow(10, val / 10.0) / 1.6;
+            }
+
+        }
         graph[i] = aud::clamp ((int) val, 0, int_range);
     }
 }
@@ -148,7 +161,7 @@ void VisCallbacks::render_freq (const float * freq)
         if (config.analyzer_type == ANALYZER_BARS)
         {
             if (shaded)
-                make_log_graph (freq, 13, 40, 8, data);
+                make_log_graph (freq, 10, 40, 8, data);
             else
                 make_log_graph (freq, 19, 40, 16, data);
         }

--- a/src/skins/vis.cc
+++ b/src/skins/vis.cc
@@ -31,16 +31,21 @@
 #include "skin.h"
 #include "vis.h"
 
-static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
-static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
-static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 10, 19, 19, 18,
- 19, 19, 20, 20, 21, 21, 22};
+static const float vis_afalloff_speeds[] = {0.19, 0.422, 0.75, 1.0, 2.0};
+static const float vis_pfalloff_speeds[] = {1.1, 1.15, 1.25, 1.4, 1.75};
+static const int vis_scope_colors[16] = {21, 21, 20, 20, 19, 19, 18, 18, 19,
+ 19, 20, 20, 21, 21, 22, 22};
 
 #define RGB_SEEK(x,y) (set = rgb + 76 * (y) + (x))
 #define RGB_SET(c) (* set ++ = (c))
 #define RGB_SET_Y(c) do {* set = (c); set += 76;} while (0)
 #define RGB_SET_INDEX(c) RGB_SET (skin.vis_colors[c])
 #define RGB_SET_INDEX_Y(c) RGB_SET_Y (skin.vis_colors[c])
+
+bool SkinnedVis::button_press (GdkEventButton * event)
+{
+    return press ? press (event) : false;
+}
 
 void SkinnedVis::set_colors ()
 {
@@ -105,7 +110,7 @@ void SkinnedVis::draw (cairo_t * cr)
             if (bars && (x & 3) == 3)
                 continue;
 
-            int h = m_data[bars ? (x >> 2) : x];
+            int h = m_datafalloff[bars ? (x >> 2) : x];
             h = aud::clamp (h, 0, 16);
             RGB_SEEK (x, 16 - h);
 
@@ -117,23 +122,26 @@ void SkinnedVis::draw (cairo_t * cr)
                 break;
             case ANALYZER_FIRE:
                 for (int y = 0; y < h; y ++)
-                    RGB_SET_INDEX_Y (2 + y);
+                    RGB_SET_INDEX_Y (3 + y);
                 break;
             default: /* ANALYZER_VLINES */
                 for (int y = 0; y < h; y ++)
                     RGB_SET_INDEX_Y (18 - h);
                 break;
             }
-
+        
             if (config.analyzer_peaks)
             {
-                int h = m_peak[bars ? (x >> 2) : x];
+                int h;
+                h = m_truepeaks[bars ? (x >> 2) : x];
                 h = aud::clamp (h, 0, 16);
 
                 if (h)
                 {
-                    RGB_SEEK (x, 16 - h);
-                    RGB_SET_INDEX (23);
+                    if (h > 1){
+                        RGB_SEEK (x, 16 - h);
+                        RGB_SET_INDEX (23);
+                    }
                 }
             }
         }
@@ -172,46 +180,51 @@ void SkinnedVis::draw (cairo_t * cr)
         case SCOPE_DOT:
             for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
+                int h = aud::clamp ((int) m_data[x] - 1, 0, 15);
                 RGB_SEEK (x, h);
                 RGB_SET_INDEX (vis_scope_colors[h]);
             }
             break;
         case SCOPE_LINE:
         {
-            for (int x = 0; x < 74; x ++)
+            for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
-                int h2 = aud::clamp ((int) m_data[x + 1], 0, 15);
+                int h = aud::clamp ((int) m_data[x] - 1, 0, 15);
 
-                if (h < h2)
-                    h2 --;
-                else if (h > h2)
-                {
-                    int temp = h;
-                    h = h2 + 1;
-                    h2 = temp;
+                    if (x == 0) {
+                        last_h = h;
+                    }
+
+                    top = h;
+                    bottom = last_h;
+                    last_h = h;
+
+                    if (bottom < top) {
+                        int temp = bottom;
+                        bottom = top;
+                        top = temp + 1;
+                    }
+
+                for (int y = top; y <= bottom; y ++) {
+                    RGB_SEEK (x, y);
+                    RGB_SET_INDEX_Y (vis_scope_colors[h]);
                 }
-
-                RGB_SEEK (x, h);
-
-                for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[y]);
             }
 
-            int h = aud::clamp ((int) m_data[74], 0, 15);
-            RGB_SEEK (74, h);
-            RGB_SET_INDEX (vis_scope_colors[h]);
+/*             int h = aud::clamp ((int) m_data[5], 0, 15) + 1;
+            RGB_SEEK (75, h);
+            RGB_SET_INDEX (vis_scope_colors[h]); */
             break;
         }
         default: /* SCOPE_SOLID */
             for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
+                int h = aud::clamp ((int) m_data[x] - 1, 0, 15);
+                int h3 = aud::clamp ((int) m_data[x] - 1, 0, 15); // get full data instead of just one half
                 int h2;
 
                 if (h < 8)
-                    h2 = 8;
+                    h2 = 7;
                 else
                 {
                     h2 = h;
@@ -221,7 +234,7 @@ void SkinnedVis::draw (cairo_t * cr)
                 RGB_SEEK (x, h);
 
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (vis_scope_colors[h3]);
             }
             break;
         }
@@ -231,7 +244,13 @@ void SkinnedVis::draw (cairo_t * cr)
 DRAW:
     cairo_surface_t * surf = cairo_image_surface_create_for_data
      ((unsigned char *) rgb, CAIRO_FORMAT_RGB24, 76, 16, 4 * 76);
-    cairo_set_source_surface (cr, surf, 0, 0);
+    int y;
+    if (config.scale == 1) {
+        y = 2;
+    } else {
+        y = 0;
+    }
+    cairo_set_source_surface (cr, surf, 0, y);
     cairo_pattern_set_filter (cairo_get_source (cr), CAIRO_FILTER_NEAREST);
     cairo_paint (cr);
     cairo_surface_destroy (surf);
@@ -249,9 +268,8 @@ void SkinnedVis::clear ()
     m_active = false;
     m_voiceprint_advance = false;
 
-    memset (m_data, 0, sizeof m_data);
-    memset (m_peak, 0, sizeof m_peak);
-    memset (m_peak_speed, 0, sizeof m_peak_speed);
+    memset (m_datafalloff, 0, sizeof m_datafalloff);
+    memset (m_truepeaks, 0, sizeof m_truepeaks);
     memset (m_voiceprint_data, 0, sizeof m_voiceprint_data);
 
     queue_draw ();
@@ -261,47 +279,26 @@ void SkinnedVis::render (const unsigned char * data)
 {
     if (config.vis_type == VIS_ANALYZER)
     {
-        const int n = (config.analyzer_type == ANALYZER_BARS) ? 19 : 75;
-
+    const int n = (config.analyzer_type == ANALYZER_BARS) ? 19 : 75;
         for (int i = 0; i < n; i ++)
         {
-            if (data[i] > m_data[i])
-            {
-                m_data[i] = data[i];
-                if (m_data[i] > m_peak[i])
-                {
-                    m_peak[i] = m_data[i];
-                    m_peak_speed[i] = 0.01;
+            m_data[i] = data[i];
+            m_data[i] = aud::clamp(static_cast<int>(m_data[i]), 0, 15);
+            m_datafalloff[i] -= (vis_afalloff_speeds[config.analyzer_falloff]) * 2;
 
-                }
-                else if (m_peak[i] > 0.0)
-                {
-                    m_peak[i] -= m_peak_speed[i];
-                    m_peak_speed[i] *= vis_pfalloff_speeds[config.peaks_falloff];
-                    if (m_peak[i] < m_data[i])
-                        m_peak[i] = m_data[i];
-                    if (m_peak[i] < 0.0)
-                        m_peak[i] = 0.0;
-                }
+            if (m_datafalloff[i] <= m_data[i]) {
+                m_datafalloff[i] = m_data[i];
             }
-            else
-            {
-                if (m_data[i] > 0.0)
-                {
-                    m_data[i] -= vis_afalloff_speeds[config.analyzer_falloff];
-                    if (m_data[i] < 0.0)
-                        m_data[i] = 0.0;
-                }
-                if (m_peak[i] > 0.0)
-                {
-                    m_peak[i] -= m_peak_speed[i];
-                    m_peak_speed[i] *= vis_pfalloff_speeds[config.peaks_falloff];
-                    if (m_peak[i] < m_data[i])
-                        m_peak[i] = m_data[i];
-                    if (m_peak[i] < 0.0)
-                        m_peak[i] = 0.0;
-                }
+
+            if (m_peak[i] <= (int)((m_datafalloff[i] + 1) * 256)){
+                m_peak[i] = (int)((m_datafalloff[i] + 1) * 256);
+                m_data2[i] = 3.0f;
             }
+
+            m_truepeaks[i] = m_peak[i]/256;
+
+            m_peak[i] -= (int)m_data2[i];
+            m_data2[i] *= (vis_pfalloff_speeds[config.peaks_falloff]);
         }
     }
     else if (config.vis_type == VIS_VOICEPRINT)

--- a/src/skins/vis.h
+++ b/src/skins/vis.h
@@ -59,9 +59,12 @@ public:
     void set_colors ();
     void clear ();
     void render (const unsigned char * data);
+    typedef bool (* PressCB) (GdkEventButton *);
+    void on_press (PressCB callback) { press = callback; }
 
 private:
     void draw (cairo_t * cr);
+    virtual bool button_press (GdkEventButton * event);
 
     uint32_t m_voice_color[256];
     uint32_t m_voice_color_fire[256];
@@ -69,8 +72,15 @@ private:
     uint32_t m_pattern_fill[76 * 2];
 
     bool m_active, m_voiceprint_advance;
-    float m_data[75], m_peak[75], m_peak_speed[75];
+    float m_data[75] = {0};
+    float m_peak[75] = {0};
+    float m_data2[75] = {0};
+    float m_datafalloff[75] = {0};
+    float m_data4[75] = {0};
+    float m_truepeaks[75] = {0};
+    int top, bottom, last_h;
     unsigned char m_voiceprint_data[76 * 16];
+    PressCB press = nullptr;
 };
 
 class SmallVis : public Widget
@@ -79,12 +89,22 @@ public:
     SmallVis ();
     void clear ();
     void render (const unsigned char * data);
+    typedef bool (* PressCB) (GdkEventButton *);
+    void on_press (PressCB callback) { press = callback; }
 
 private:
     void draw (cairo_t * cr);
+    virtual bool button_press (GdkEventButton * event);
 
     bool m_active;
-    int m_data[75];
+    float m_data[75] = {0};
+    float m_peak[75] = {0};
+    float m_data2[75] = {0};
+    float m_datafalloff[75] = {0};
+    float m_data4[75] = {0};
+    float m_truepeaks[75] = {0};
+    int top, bottom, last_h;
+    PressCB press = nullptr;
 };
 
 #endif


### PR DESCRIPTION
This PR aims to improve the Winamp Skin support for both the GTK and Qt mode, the following was done:

- Improved visualizer accuracy to match behavior with Winamp where possible
- Leading Zeroes by default
- Clutter bar/Menu row is always visible and shows what is currently active (Doublesize mode, Always-On-Top)
- Changed Clutter bar/Menu row status text to more match what Winamp shows
- Songticker no longer shows ---
- Visualizer no longer clears with almost every playback related action
- Visualizer can now cycle through the modes by clicking on it (It doesn't work in the GTK version, but to be honest, I don't have a clue how GTK works...)

Edit: I forgot to mention this, but I was looking to enable the visualizer to run at 60fps but couldn't find a way, are there any pointers for this?