### PR TITLE
Wayland fixes

### DIFF
--- a/src/gtkui/ui_gtk.cc
+++ b/src/gtkui/ui_gtk.cc
@@ -980,7 +980,6 @@ bool GtkUI::init ()
 
     timer_add (TimerRate::Hz4, ui_volume_slider_update, volume);
 
-    g_signal_connect (window, "map-event", (GCallback) pl_notebook_grab_focus, nullptr);
     g_signal_connect (window, "delete-event", (GCallback) window_delete, nullptr);
     g_signal_connect (window, "window-state-event", (GCallback) window_state_cb, nullptr);
     g_signal_connect (window, "key-press-event", (GCallback) window_keypress_cb, nullptr);

--- a/src/gtkui/ui_infoarea.cc
+++ b/src/gtkui/ui_infoarea.cc
@@ -370,12 +370,6 @@ static void ui_infoarea_playback_stop ()
     timer_add (TimerRate::Hz30, ui_infoarea_do_fade);
 }
 
-static void realize_cb (GtkWidget * widget)
-{
-    /* using a native window avoids redrawing parent widgets */
-    gdk_window_ensure_native (gtk_widget_get_window (widget));
-}
-
 void ui_infoarea_show_art (bool show)
 {
     if (! area)
@@ -397,9 +391,6 @@ void ui_infoarea_show_vis (bool show)
             return;
 
         vis.widget = gtk_drawing_area_new ();
-
-        /* note: "realize" signal must be connected before adding to box */
-        g_signal_connect (vis.widget, "realize", (GCallback) realize_cb, nullptr);
 
         gtk_widget_set_size_request (vis.widget, VIS_WIDTH, HEIGHT);
         gtk_box_pack_start ((GtkBox *) area->box, vis.widget, false, false, 0);

--- a/src/skins-qt/plugin.cc
+++ b/src/skins-qt/plugin.cc
@@ -22,6 +22,7 @@
 #include <glib.h>
 
 #include <QApplication>
+#include <QGuiApplication>
 #include <QPointer>
 
 #include <libaudcore/audstrings.h>
@@ -172,6 +173,14 @@ bool QtSkins::init ()
 
     if (! load_initial_skin ())
     {
+        audqt::cleanup ();
+        return false;
+    }
+
+    if (QGuiApplication::platformName() == "wayland")
+    {
+        AUDERR ("The Winamp interface is not supported on Wayland. "
+                "Please run Audacious via XWayland.\n");
         audqt::cleanup ();
         return false;
     }

--- a/src/skins/plugin.cc
+++ b/src/skins/plugin.cc
@@ -30,6 +30,10 @@
 #include <libaudgui/libaudgui.h>
 #include <libaudgui/libaudgui-gtk.h>
 
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+
 #include "menus.h"
 #include "plugin.h"
 #include "plugin-window.h"
@@ -164,6 +168,17 @@ bool SkinnedUI::init ()
         return false;
 
     audgui_init ();
+
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default ()))
+    {
+        AUDERR ("The Winamp interface is not supported on Wayland. "
+                "Please run Audacious via XWayland.\n");
+        audgui_cleanup ();
+        return false;
+    }
+#endif
+
     menu_init ();
     skins_init_main (false);
 


### PR DESCRIPTION
Fixes for Audacious when running on Wayland, see the commit messages for more details.

Tested with `QT_QPA_PLATFORM=wayland audacious` and `GDK_BACKEND=wayland audacious --gtk` on Ubuntu 24.04.