### PR TITLE
Set parent window for infopopup

### DIFF
--- a/src/gtkui/gtkui.h
+++ b/src/gtkui/gtkui.h
@@ -37,6 +37,7 @@ extern Playlist menu_tab_playlist;
 extern const PluginPreferences gtkui_prefs;
 
 /* ui_gtk.c */
+GtkWindow * get_main_window ();
 void show_hide_menu ();
 void show_hide_infoarea ();
 void show_hide_infoarea_art ();

--- a/src/gtkui/ui_gtk.cc
+++ b/src/gtkui/ui_gtk.cc
@@ -1031,6 +1031,11 @@ void GtkUI::cleanup ()
     audgui_cleanup ();
 }
 
+GtkWindow * get_main_window ()
+{
+    return (GtkWindow *) window;
+}
+
 #ifndef USE_GTK3
 static void menu_position_cb (GtkMenu *, int * x, int * y, int * push, void * button)
 {

--- a/src/gtkui/ui_playlist_widget.cc
+++ b/src/gtkui/ui_playlist_widget.cc
@@ -126,7 +126,10 @@ struct PlaylistWidgetData
     QueuedFunc popup_timer;
 
     void show_popup ()
-        { audgui_infopopup_show (list, popup_pos); }
+    {
+        GtkWindow * parent = get_main_window ();
+        audgui_infopopup_show (parent, list, popup_pos);
+    }
 };
 
 static void set_int_from_tuple (GValue * value, const Tuple & tuple, Tuple::Field field)

--- a/src/skins/main.cc
+++ b/src/skins/main.cc
@@ -39,6 +39,7 @@
 #include <libaudcore/plugins.h>
 #include <libaudcore/runtime.h>
 #include <libaudgui/libaudgui.h>
+#include <libaudgui/libaudgui-gtk.h>
 
 #include "actions-mainwin.h"
 #include "actions-playlist.h"
@@ -366,6 +367,12 @@ static void mainwin_set_song_info (int bitrate, int samplerate, int channels)
     mainwin_set_othertext (scratch);
 }
 
+static void mainwin_show_infopopup ()
+{
+    GtkWindow * parent = (GtkWindow *) mainwin->gtk ();
+    audgui_infopopup_show_current (parent);
+}
+
 static void info_change ()
 {
     int bitrate, samplerate, channels;
@@ -531,7 +538,7 @@ bool MainWindow::motion (GdkEventMotion * event)
         if (! m_popup_shown)
         {
             m_popup_timer.queue (aud_get_int ("filepopup_delay") * 100,
-             audgui_infopopup_show_current);
+             mainwin_show_infopopup);
             m_popup_shown = true;
         }
     }

--- a/src/skins/playlist-widget.cc
+++ b/src/skins/playlist-widget.cc
@@ -34,6 +34,8 @@
 #include "skin.h"
 #include "playlist-widget.h"
 #include "playlist-slider.h"
+#include "playlistwin.h"
+#include "window.h"
 
 #include <libaudcore/audstrings.h>
 #include <libaudcore/hook.h>
@@ -41,6 +43,7 @@
 #include <libaudcore/runtime.h>
 #include <libaudcore/playlist.h>
 #include <libaudgui/libaudgui.h>
+#include <libaudgui/libaudgui-gtk.h>
 
 enum {
     DRAG_SELECT = 1,
@@ -794,12 +797,13 @@ void PlaylistWidget::popup_trigger (int pos)
 
     m_popup_pos = pos;
     m_popup_timer.queue (aud_get_int ("filepopup_delay") * 100,
-     [this] () { popup_show(); });
+     [this] () { popup_show (); });
 }
 
 void PlaylistWidget::popup_show ()
 {
-    audgui_infopopup_show (m_playlist, m_popup_pos);
+    GtkWindow * parent = (GtkWindow *) playlistwin->gtk ();
+    audgui_infopopup_show (parent, m_playlist, m_popup_pos);
 }
 
 void PlaylistWidget::popup_hide ()


### PR DESCRIPTION
Follow-up for the infopopup changes in libaudgui from https://github.com/audacious-media-player/audacious/pull/1399.