### PR TITLE
sndio: Make use of the sio_flush() function

### DIFF
--- a/src/sndio/meson.build
+++ b/src/sndio/meson.build
@@ -1,4 +1,4 @@
-sndio_dep = dependency('sndio', required: false)
+sndio_dep = dependency('sndio', version: '>= 1.9.0', required: false)
 have_sndio = sndio_dep.found()
 
 

--- a/src/sndio/sndio.cc
+++ b/src/sndio/sndio.cc
@@ -344,7 +344,7 @@ void SndioPlugin::flush ()
 {
     pthread_mutex_lock (& m_mutex);
 
-    sio_stop (m_handle);
+    sio_flush (m_handle);
 
     m_frames_buffered = 0;
     m_last_write_time = timeval ();


### PR DESCRIPTION
Use sio_flush() instead of sio_stop() to improve controls responsiveness.