### PR TITLE
CI: remove dbus-glib dependency

### DIFF
--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -19,7 +19,7 @@ fi
 
 ubuntu_packages='gettext libadplug-dev libasound2-dev libavformat-dev
                  libbinio-dev libbs2b-dev libcddb2-dev libcdio-cdda-dev
-                 libcue-dev libcurl4-gnutls-dev libdbus-glib-1-dev
+                 libcue-dev libcurl4-gnutls-dev
                  libfaad-dev libflac-dev libfluidsynth-dev libgl1-mesa-dev
                  libjack-jackd2-dev libjson-glib-dev libmms-dev libmodplug-dev
                  libmp3lame-dev libmpg123-dev libneon27-gnutls-dev libnotify-dev


### PR DESCRIPTION
The last usage of dbus-glib has been removed in https://github.com/audacious-media-player/audacious-plugins/commit/3dc8222f59bc8a2352fc0bac54e34a22adc6e122