### PR TITLE
mpris2: send more metadata about current track

### DIFF
--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -126,7 +126,7 @@ void add_g_variant_str(const char * key_str, const char * value_str,
 void add_g_variant_int32(const char * key_str, int32_t value_int,
                          std::vector<GVariant *> & elems)
 {
-    if (!value_int)
+    if (!value_int || value_int < 0)
         return;
 
     GVariant * key = g_variant_new_string(key_str);
@@ -138,7 +138,7 @@ void add_g_variant_int32(const char * key_str, int32_t value_int,
 void add_g_variant_int64(const char * key_str, int64_t value_int,
                          std::vector<GVariant *> & elems)
 {
-    if (!value_int)
+    if (!value_int || value_int < 0)
         return;
 
     GVariant * key = g_variant_new_string(key_str);

--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -79,6 +79,7 @@ struct MPRIS2Metadata
     String genre;
     String rec_date;
     String composer;
+    String lyrics;
     String file;
     int32_t track = -1;
     int64_t length = -1;
@@ -171,6 +172,7 @@ static void update_metadata (void * data, GObject * object)
         meta.comment = tuple.get_str (Tuple::Comment);
         meta.genre = tuple.get_str (Tuple::Genre);
         meta.composer = tuple.get_str (Tuple::Composer);
+        meta.lyrics = tuple.get_str (Tuple::Lyrics);
         meta.track = tuple.get_int (Tuple::Track);
         meta.length = tuple.get_int (Tuple::Length);
         meta.disc = tuple.get_int (Tuple::Disc);
@@ -215,6 +217,8 @@ static void update_metadata (void * data, GObject * object)
         add_g_variant_str ("xesam:contentCreated", meta.rec_date, elems);
     if (meta.composer)
         add_g_variant_arr_str ("xesam:composer", {meta.composer}, elems);
+    if (meta.lyrics)
+        add_g_variant_str ("xesam:asText", meta.lyrics, elems);
     if (meta.file)
         add_g_variant_str ("xesam:url", meta.file, elems);
     if (meta.track > 0)

--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -144,18 +144,21 @@ static MPRIS2Metadata last_meta;
 void add_g_variant_str(const char * key_str, const char * value_str,
                        std::vector<GVariant *> & elems)
 {
-    if (value_str)
-    {
-        GVariant * key = g_variant_new_string(key_str);
-        GVariant * str = g_variant_new_string(value_str);
-        GVariant * var = g_variant_new_variant(str);
-        elems.push_back(g_variant_new_dict_entry(key, var));
-    }
+    if (!value_str)
+        return;
+
+    GVariant * key = g_variant_new_string(key_str);
+    GVariant * str = g_variant_new_string(value_str);
+    GVariant * var = g_variant_new_variant(str);
+    elems.push_back(g_variant_new_dict_entry(key, var));
 }
 
 void add_g_variant_int32(const char * key_str, int32_t value_int,
                          std::vector<GVariant *> & elems)
 {
+    if (!value_int)
+        return;
+
     GVariant * key = g_variant_new_string(key_str);
     GVariant * num = g_variant_new_int32(value_int);
     GVariant * var = g_variant_new_variant(num);
@@ -165,6 +168,9 @@ void add_g_variant_int32(const char * key_str, int32_t value_int,
 void add_g_variant_int64(const char * key_str, int64_t value_int,
                          std::vector<GVariant *> & elems)
 {
+    if (!value_int)
+        return;
+
     GVariant * key = g_variant_new_string(key_str);
     GVariant * num = g_variant_new_int64(value_int);
     GVariant * var = g_variant_new_variant(num);
@@ -175,20 +181,19 @@ void add_g_variant_arr(const char * key_str,
                        const std::vector<const char *> & value_arr,
                        std::vector<GVariant *> & elems)
 {
-    if (!value_arr.empty())
+    if (value_arr.empty())
+        return;
+
+    GVariant * key = g_variant_new_string(key_str);
+    std::vector<GVariant *> g_variant_array;
+    for (const auto & item : value_arr)
     {
-        GVariant * key = g_variant_new_string(key_str);
-        std::vector<GVariant *> g_variant_array;
-        for (const auto & item : value_arr)
-        {
-            g_variant_array.push_back(g_variant_new_string(item));
-        }
-        GVariant * array =
-            g_variant_new_array(G_VARIANT_TYPE_STRING, g_variant_array.data(),
-                                g_variant_array.size());
-        GVariant * var = g_variant_new_variant(array);
-        elems.push_back(g_variant_new_dict_entry(key, var));
+        g_variant_array.push_back(g_variant_new_string(item));
     }
+    GVariant * array = g_variant_new_array(
+        G_VARIANT_TYPE_STRING, g_variant_array.data(), g_variant_array.size());
+    GVariant * var = g_variant_new_variant(array);
+    elems.push_back(g_variant_new_dict_entry(key, var));
 }
 
 static void update_metadata(void * data, GObject * object)
@@ -221,17 +226,28 @@ static void update_metadata(void * data, GObject * object)
 
     std::vector<GVariant *> elems;
 
-    add_g_variant_str("xesam:title", meta.title, elems);
-    add_g_variant_arr("xesam:artist", {meta.artist}, elems);
-    add_g_variant_str("xesam:album", meta.album, elems);
-    add_g_variant_arr("xesam:albumArtist", {meta.album_artist}, elems);
-    add_g_variant_arr("xesam:comment", {meta.comment}, elems);
-    add_g_variant_arr("xesam:genre", {meta.genre}, elems);
-    add_g_variant_arr("xesam:composer", {meta.composer}, elems);
-    add_g_variant_str("xesam:url", meta.file, elems);
-    add_g_variant_int32("xesam:trackNumber", meta.track, elems);
-    add_g_variant_int64("mpris:length", meta.length * 1000, elems);
-    add_g_variant_int32("xesam:discNumber", meta.disc, elems);
+    if (meta.title)
+        add_g_variant_str("xesam:title", meta.title, elems);
+    if (meta.artist)
+        add_g_variant_arr("xesam:artist", {meta.artist}, elems);
+    if (meta.album)
+        add_g_variant_str("xesam:album", meta.album, elems);
+    if (meta.album_artist)
+        add_g_variant_arr("xesam:albumArtist", {meta.album_artist}, elems);
+    if (meta.comment)
+        add_g_variant_arr("xesam:comment", {meta.comment}, elems);
+    if (meta.genre)
+        add_g_variant_arr("xesam:genre", {meta.genre}, elems);
+    if (meta.composer)
+        add_g_variant_arr("xesam:composer", {meta.composer}, elems);
+    if (meta.file)
+        add_g_variant_str("xesam:url", meta.file, elems);
+    if (meta.track)
+        add_g_variant_int32("xesam:trackNumber", meta.track, elems);
+    if (meta.length)
+        add_g_variant_int64("mpris:length", meta.length * 1000, elems);
+    if (meta.disc)
+        add_g_variant_int32("xesam:discNumber", meta.disc, elems);
 
     auto image_file = meta.image.file();
     add_g_variant_str("mpris:artUrl", image_file, elems);

--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -85,37 +85,6 @@ struct MPRIS2Metadata
 
     MPRIS2Metadata() = default;
 
-    MPRIS2Metadata(MPRIS2Metadata && other) noexcept
-        : title(std::move(other.title)), artist(std::move(other.artist)),
-          album(std::move(other.album)),
-          album_artist(std::move(other.album_artist)),
-          comment(std::move(other.comment)), genre(std::move(other.genre)),
-          composer(std::move(other.composer)), file(std::move(other.file)),
-          track(other.track), length(other.length), disc(other.disc),
-          image(std::move(other.image))
-    {
-    }
-
-    MPRIS2Metadata & operator=(MPRIS2Metadata && other) noexcept
-    {
-        if (this != &other)
-        {
-            title = std::move(other.title);
-            artist = std::move(other.artist);
-            album = std::move(other.album);
-            album_artist = std::move(other.album_artist);
-            comment = std::move(other.comment);
-            genre = std::move(other.genre);
-            composer = std::move(other.composer);
-            file = std::move(other.file);
-            track = other.track;
-            length = other.length;
-            disc = other.disc;
-            image = std::move(other.image);
-        }
-        return *this;
-    }
-
     bool operator==(const MPRIS2Metadata & other) const
     {
         return title == other.title && artist == other.artist &&
@@ -131,10 +100,11 @@ struct MPRIS2Metadata
         return !(*this == other);
     }
 
+    MPRIS2Metadata(MPRIS2Metadata && other) = default;
+    MPRIS2Metadata & operator=(MPRIS2Metadata && other) = default;
     MPRIS2Metadata(const MPRIS2Metadata &) = delete;
     MPRIS2Metadata & operator=(const MPRIS2Metadata &) = delete;
-
-    ~MPRIS2Metadata() { image.clear(); }
+    ~MPRIS2Metadata() = default;
 };
 
 static MPRIS2Metadata last_meta;

--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -83,8 +83,6 @@ struct MPRIS2Metadata
     int32_t disc = -1;
     AudArtPtr image;
 
-    MPRIS2Metadata() = default;
-
     bool operator==(const MPRIS2Metadata & other) const
     {
         return title == other.title && artist == other.artist &&
@@ -99,12 +97,6 @@ struct MPRIS2Metadata
     {
         return !(*this == other);
     }
-
-    MPRIS2Metadata(MPRIS2Metadata && other) = default;
-    MPRIS2Metadata & operator=(MPRIS2Metadata && other) = default;
-    MPRIS2Metadata(const MPRIS2Metadata &) = delete;
-    MPRIS2Metadata & operator=(const MPRIS2Metadata &) = delete;
-    ~MPRIS2Metadata() = default;
 };
 
 static MPRIS2Metadata last_meta;

--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -83,19 +83,19 @@ struct MPRIS2Metadata
     int32_t disc = -1;
     AudArtPtr image;
 
-    bool operator==(const MPRIS2Metadata & other) const
+    bool operator== (const MPRIS2Metadata & other) const
     {
-        return title == other.title && artist == other.artist &&
-               album == other.album && album_artist == other.album_artist &&
-               comment == other.comment && genre == other.genre &&
-               composer == other.composer && file == other.file &&
-               track == other.track && length == other.length &&
-               disc == other.disc;
+        return title == other.title && artist == other.artist
+               && album == other.album && album_artist == other.album_artist
+               && comment == other.comment && genre == other.genre
+               && composer == other.composer && file == other.file
+               && track == other.track && length == other.length
+               && disc == other.disc;
     }
 
-    bool operator!=(const MPRIS2Metadata & other) const
+    bool operator!= (const MPRIS2Metadata & other) const
     {
-        return !(*this == other);
+        return ! (*this == other);
     }
 };
 
@@ -103,76 +103,76 @@ static MPRIS2Metadata last_meta;
 
 /* Helper functions to handle GVariant creation */
 
-void add_g_variant_str(const char * key_str, const char * value_str,
+void add_g_variant_str (const char * key_str, const char * value_str,
                        std::vector<GVariant *> & elems)
 {
-    if (!value_str || strlen(value_str) == 0)
+    if (! value_str || strlen (value_str) == 0)
         return;
 
-    GVariant * key = g_variant_new_string(key_str);
-    GVariant * str = g_variant_new_string(value_str);
-    GVariant * var = g_variant_new_variant(str);
-    elems.push_back(g_variant_new_dict_entry(key, var));
+    GVariant * key = g_variant_new_string (key_str);
+    GVariant * str = g_variant_new_string (value_str);
+    GVariant * var = g_variant_new_variant (str);
+    elems.push_back (g_variant_new_dict_entry (key, var));
 }
 
-void add_g_variant_int32(const char * key_str, int32_t value_int,
+void add_g_variant_int32 (const char * key_str, int32_t value_int,
                          std::vector<GVariant *> & elems)
 {
-    GVariant * key = g_variant_new_string(key_str);
-    GVariant * num = g_variant_new_int32(value_int);
-    GVariant * var = g_variant_new_variant(num);
-    elems.push_back(g_variant_new_dict_entry(key, var));
+    GVariant * key = g_variant_new_string (key_str);
+    GVariant * num = g_variant_new_int32 (value_int);
+    GVariant * var = g_variant_new_variant (num);
+    elems.push_back (g_variant_new_dict_entry (key, var));
 }
 
-void add_g_variant_int64(const char * key_str, int64_t value_int,
+void add_g_variant_int64 (const char * key_str, int64_t value_int,
                          std::vector<GVariant *> & elems)
 {
-    GVariant * key = g_variant_new_string(key_str);
-    GVariant * num = g_variant_new_int64(value_int);
-    GVariant * var = g_variant_new_variant(num);
-    elems.push_back(g_variant_new_dict_entry(key, var));
+    GVariant * key = g_variant_new_string (key_str);
+    GVariant * num = g_variant_new_int64 (value_int);
+    GVariant * var = g_variant_new_variant (num);
+    elems.push_back (g_variant_new_dict_entry (key, var));
 }
 
-void add_g_variant_arr_str(const char * key_str,
+void add_g_variant_arr_str (const char * key_str,
                            const std::vector<const char *> & value_arr,
                            std::vector<GVariant *> & elems)
 {
-    if (value_arr.empty())
+    if (value_arr.empty ())
         return;
 
-    GVariant * key = g_variant_new_string(key_str);
+    GVariant * key = g_variant_new_string (key_str);
     std::vector<GVariant *> g_variant_array;
     for (const auto & item : value_arr)
     {
-        if (!item || strlen(item) == 0)
+        if (! item || strlen (item) == 0)
             continue;
-        g_variant_array.push_back(g_variant_new_string(item));
+        g_variant_array.push_back (g_variant_new_string (item));
     }
-    GVariant * array = g_variant_new_array(
-        G_VARIANT_TYPE_STRING, g_variant_array.data(), g_variant_array.size());
-    GVariant * var = g_variant_new_variant(array);
-    elems.push_back(g_variant_new_dict_entry(key, var));
+    GVariant * array = g_variant_new_array (
+        G_VARIANT_TYPE_STRING, g_variant_array.data (), g_variant_array.size ());
+    GVariant * var = g_variant_new_variant (array);
+    elems.push_back (g_variant_new_dict_entry (key, var));
 }
 
-static void update_metadata(void * data, GObject * object)
+static void update_metadata (void * data, GObject * object)
 {
     MPRIS2Metadata meta;
 
-    if (aud_drct_get_ready())
+    if (aud_drct_get_ready ())
     {
-        Tuple tuple = aud_drct_get_tuple();
+        Tuple tuple = aud_drct_get_tuple ();
 
-        meta.title = tuple.get_str(Tuple::Title);
-        meta.artist = tuple.get_str(Tuple::Artist);
-        meta.album = tuple.get_str(Tuple::Album);
-        meta.album_artist = tuple.get_str(Tuple::AlbumArtist);
-        meta.comment = tuple.get_str(Tuple::Comment);
-        meta.genre = tuple.get_str(Tuple::Genre);
-        meta.composer = tuple.get_str(Tuple::Composer);
-        meta.track = tuple.get_int(Tuple::Track);
-        meta.length = tuple.get_int(Tuple::Length);
-        meta.disc = tuple.get_int(Tuple::Disc);
-        meta.file = aud_drct_get_filename();
+        meta.title = tuple.get_str (Tuple::Title);
+        meta.artist = tuple.get_str (Tuple::Artist);
+        meta.album = tuple.get_str (Tuple::Album);
+        meta.album_artist = tuple.get_str (Tuple::AlbumArtist);
+        meta.comment = tuple.get_str (Tuple::Comment);
+        meta.genre = tuple.get_str (Tuple::Genre);
+        meta.composer = tuple.get_str (Tuple::Composer);
+        meta.track = tuple.get_int (Tuple::Track);
+        meta.length = tuple.get_int (Tuple::Length);
+        meta.disc = tuple.get_int (Tuple::Disc);
+        meta.file = aud_drct_get_filename ();
     }
 
     if (meta == last_meta)
@@ -180,47 +180,47 @@ static void update_metadata(void * data, GObject * object)
 
     if (meta.file != last_meta.file)
         meta.image =
-            meta.file ? aud_art_request(meta.file, AUD_ART_FILE) : AudArtPtr();
+            meta.file ? aud_art_request (meta.file, AUD_ART_FILE) : AudArtPtr ();
 
     std::vector<GVariant *> elems;
 
     if (meta.title)
-        add_g_variant_str("xesam:title", meta.title, elems);
+        add_g_variant_str ("xesam:title", meta.title, elems);
     if (meta.artist)
-        add_g_variant_arr_str("xesam:artist", {meta.artist}, elems);
+        add_g_variant_arr_str ("xesam:artist", {meta.artist}, elems);
     if (meta.album)
-        add_g_variant_str("xesam:album", meta.album, elems);
+        add_g_variant_str ("xesam:album", meta.album, elems);
     if (meta.album_artist)
-        add_g_variant_arr_str("xesam:albumArtist", {meta.album_artist}, elems);
+        add_g_variant_arr_str ("xesam:albumArtist", {meta.album_artist}, elems);
     if (meta.comment)
-        add_g_variant_arr_str("xesam:comment", {meta.comment}, elems);
+        add_g_variant_arr_str ("xesam:comment", {meta.comment}, elems);
     if (meta.genre)
-        add_g_variant_arr_str("xesam:genre", {meta.genre}, elems);
+        add_g_variant_arr_str ("xesam:genre", {meta.genre}, elems);
     if (meta.composer)
-        add_g_variant_arr_str("xesam:composer", {meta.composer}, elems);
+        add_g_variant_arr_str ("xesam:composer", {meta.composer}, elems);
     if (meta.file)
-        add_g_variant_str("xesam:url", meta.file, elems);
+        add_g_variant_str ("xesam:url", meta.file, elems);
     if (meta.track > 0)
-        add_g_variant_int32("xesam:trackNumber", meta.track, elems);
+        add_g_variant_int32 ("xesam:trackNumber", meta.track, elems);
     if (meta.length > 0)
-        add_g_variant_int64("mpris:length", meta.length * 1000, elems);
+        add_g_variant_int64 ("mpris:length", meta.length * 1000, elems);
     if (meta.disc > 0)
-        add_g_variant_int32("xesam:discNumber", meta.disc, elems);
+        add_g_variant_int32 ("xesam:discNumber", meta.disc, elems);
 
-    auto image_file = meta.image.file();
-    add_g_variant_str("mpris:artUrl", image_file, elems);
+    auto image_file = meta.image.file ();
+    add_g_variant_str ("mpris:artUrl", image_file, elems);
 
-    GVariant * key = g_variant_new_string("mpris:trackid");
+    GVariant * key = g_variant_new_string ("mpris:trackid");
     GVariant * str =
-        g_variant_new_object_path("/org/mpris/MediaPlayer2/CurrentTrack");
-    GVariant * var = g_variant_new_variant(str);
-    elems.push_back(g_variant_new_dict_entry(key, var));
+        g_variant_new_object_path ("/org/mpris/MediaPlayer2/CurrentTrack");
+    GVariant * var = g_variant_new_variant (str);
+    elems.push_back (g_variant_new_dict_entry (key, var));
 
     GVariant * array =
-        g_variant_new_array(G_VARIANT_TYPE("{sv}"), elems.data(), elems.size());
-    g_object_set(object, "metadata", array, nullptr);
+        g_variant_new_array (G_VARIANT_TYPE ("{sv}"), elems.data (), elems.size ());
+    g_object_set (object, "metadata", array, nullptr);
 
-    last_meta = std::move(meta);
+    last_meta = std::move (meta);
 }
 
 static void volume_changed (GObject * object)


### PR DESCRIPTION
*This PR adds more MPRIS2 metadata to broadcast about the current track to "MPRIS2 Server" plugin.*

---

Compared to players like [Supersonic](https://github.com/dweymouth/supersonic/blob/3f304483834d37f1c5f3c75da414ff032e6b6dbe/backend/mpris.go#L276), [Rhythmbox](https://github.com/GNOME/rhythmbox/blob/49d903bf2b01aaebc7bae5aad1494d4abe28f116/plugins/mpris/rb-mpris-plugin.c#L546), [DeaDBeeF](https://github.com/DeaDBeeF-Player/deadbeef-mpris2-plugin/blob/fdfd00119db5128165170fb5738d60b47acdc3fb/src/mprisServer.c#L141) (via plugin) or Spotify, Audacious does not provide much metadata about the currently playing track.

<details>
<summary><i>Intercepted Examples (using dbus-python)</i></summary>

\
**Audacious:** (7)

```json
{
    "xesam:title": "apple_pie.0",
    "xesam:artist": [ "NǽnøĉÿbbŒrğ VbëřřĦōlökäävsŦ" ],
    "xesam:album": "simulated_worlds",
    "xesam:url": "file:///...%20apple_pie.0.mp3",
    "mpris:length": 6074000,
    "mpris:artUrl": "file:///tmp/audacious-temp-XD94Q2",
    "mpris:trackid": "/org/mpris/MediaPlayer2/CurrentTrack"
}
```

**Rhythmbox:** (15)

```json
{
    "mpris:trackid": "/org/mpris/MediaPlayer2/Track/737",
    "xesam:url": "file:///...%20apple_pie.0.mp3",
    "xesam:title": "apple_pie.0",
    "xesam:artist": [ "NǽnøĉÿbbŒrğ VbëřřĦōlökäävsŦ" ],
    "xesam:album": "simulated_worlds",
    "xesam:genre": [ "Post-Noise" ],
    "xesam:comment": "i am nanocyborg",
    "xesam:albumArtist": [ "NǽnøĉÿbbŒrğ VbëřřĦōlökäävsŦ" ],
    "xesam:contentCreated": "2045-01-01T00:00:00Z"
    "mpris:length": 6000000,
    "xesam:tracknumber": 20,
    "xesam:discNumber": 1,
    "xesam:useCount": 0,
    "xesam:userRating": 0.0,
    "xesam:artUrl": "file:///home/onegen/.cache/rhythmbox/album-art/./004"
}
```

**Spotify:** (11)

```json
{
    "mpris:trackid": "/com/spotify/track/4JS5k...",
    "mpris:length": 79971000,
    "mpris:artUrl": "https://i.scdn.co/image/ab67...",
    "xesam:album": "What a Wonderful World",
    "xesam:albumArtist": [ "Auvic" ],
    "xesam:artist": [ "Auvic" ],
    "xesam:autoRating": 0.11,
    "xesam:discNumber": 1,
    "xesam:title": "Dearly Dearest",
    "xesam:tracknumber": 1,
    "xesam:url": "https://open.spotify.com/track/4JS..."
}
```

**VLC Media Player:** (14)

```json
{
    "mpris:trackid": "/org/videolan/vlc/playlist/3",
    "xesam:url": "file:///...%20apple_pie.0.mp3",
    "xesam:title": "apple_pie.0",
    "xesam:artist": [ "NǽnøĉÿbbŒrğ VbëřřĦōlökäävsŦ" ],
    "xesam:album": "simulated_worlds",
    "xesam:tracknumber": 20,
    "vlc:time": 6,
    "mpris:length": 6168000,
    "xesam:genre": [ "Post-Noise" ],
    "xesam:contentCreated": "2045",
    "mpris:artUrl": "file:///home/onegen/.cache/vlc/.../art.png",
    "xesam:comment": "i am nanocyborg",
    "vlc:length": 6168,
    "vlc:publisher": 3
}
```

---

</details>

As is, Audacious only provides `xesam:title`, `xesam:artist`, `xesam:album`, `mpris:length`, `xesam:artUrl` (ex. "audacious-temp-TNGWQ2") and `xesam:url` (local path to played file).

This PR adds the following fields:

- `xesam:albumArtist`
- `xesam:comment`
- `xesam:genre`
- `xesam:composer`
- `xesam:trackNumber`
- `xesam:discNumber`

<details>
<summary><i>Example</i></summary>

```json
{
    "xesam:title": "apple_pie.0",
    "xesam:artist": [ "NǽnøĉÿbbŒrğ VbëřřĦōlökäävsŦ" ],
    "xesam:album": "simulated_worlds",
    "xesam:albumArtist": [ "NǽnøĉÿbbŒrğ VbëřřĦōlökäävsŦ" ],
    "xesam:comment": "i am nanocyborg",
    "xesam:genre": [ "Post-Noise" ],
    "xesam:url": "file:///...%20apple_pie.0.mp3",
    "xesam:tracknumber": 20,
    "mpris:length": 6074000,
    "xesam:discNumber": 1,
    "mpris:artUrl": "file:///tmp/audacious-temp-XD94Q2",
    "mpris:trackid": "/org/mpris/MediaPlayer2/CurrentTrack"
}
```

</details>

## Motivation

Providing richer metadata supports better interoperability and potentially user experience when using other tools alongside Audacious. MPRIS2 metadata is commonly used be player controllers or other music-related apps, like Last.FM/ListenBrainz scrobblers (ex. [mpris-scrobbler](https://github.com/mariusor/mpris-scrobbler) or [rescrobbled](https://github.com/InputUsername/rescrobbled) – needs as much data as it can for profile display and recording detection), Discord rich presence ([multiple](https://github.com/search?q=Discord+Presence+MPRIS&type=repositories) – the pretty fields don’t fill themselves) and others. I was working on my own ListenBrainz scrobbler, and found the amount of data  lacking. For some tracks, I had to manually link the track to MusicBrainz – it didn’t have enough data to link it itself. \
Another potential applicability are voice assistants and smart devices – a prompt "Play track 5 from disc 2 of simulated_worlds album" would only be possible with this additional metadata.

However, I recognise this may be of minor interest to Audacious and the downsides of added file size and performance may outweigh the positives. It is entirely to you all to decide, if this is a desirable addition.

## Notes

### Codebase Changes

MPRIS2 server source code was refactored to simplify adding new fields and somewhat modernise working with metadata.

- Metadata is now stored in a new `MPRIS2Metadata` struct
- `elems`, storage of DBus values to broadcast, was changed from an array to `std::vector<GVariant *>`
    - new import `<vector>`!
- Added helper methods to insert `GValues` to `elems` (multiple for different value types)

### Remaining Metadata

There are some metadata defined in [MPRIS2 specification](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata) that I wasn’t able to add, as they were not present in the metadata tuple.

- `xesam:audioBPM`
- `xesam:autoRating` (automatically-generated rating)
- `xesam:firstUsed` (datetime of first listen)
- `xesam:lastUsed` (datetime of last listen)
- `xesam:useCount` (number of times listened)
- `xesam:userRating`

There are two fields I could add, but chose not to without consultation:

- `xesam:contentCreated` (release date) – it would be possible to set this to a year by converting `Year` to a string, though this would require another new import – `<string>` – and I was unsure if I can get away with that after already adding `<vector>`. As for month and date, I was unsure if I can obtain it… Maybe `Date`? What format is it in? Seems like a lot of validation required, but idk..
- `xesam:asText` (lyrics) – very simple to add, but I was not initially sure if it’s worth it. This is potentially a very long string and most tools usually fetch the lyrics themselves. I am unsure of the weight this might have, maybe I am just paranoid.

I implemented both lyrics and release year on separate branches, see following commits:

- Lyrics: https://github.com/onegentig/audacious-plugins/commit/e0bc41a960414109881b079a2628cdd0d5d95825
- Year: https://github.com/onegentig/audacious-plugins/commit/5981f985452f6390ce9a630cc2e3dde718e2948a

I would like to hear your thoughts on them before including them.

---

I will appreciate any feedback or suggestions on how to make this work.

Thank you for your time and consideration, \
– Nurlan „onegen“ Khramezov