### PR TITLE
CI: Switch from MINGW64 to UCRT64

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -20,33 +20,33 @@ runs:
     - uses: msys2/setup-msys2@v2
       if: startsWith(inputs.os, 'windows')
       with:
-        msystem: MINGW64
+        msystem: UCRT64
         update: true
         install: >-
-          mingw-w64-x86_64-autotools
-          mingw-w64-x86_64-faad2
-          mingw-w64-x86_64-ffmpeg
-          mingw-w64-x86_64-flac
-          mingw-w64-x86_64-fluidsynth
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-gtk2
-          mingw-w64-x86_64-json-glib
-          mingw-w64-x86_64-lame
-          mingw-w64-x86_64-libbs2b
-          mingw-w64-x86_64-libcdio-paranoia
-          mingw-w64-x86_64-libcue
-          mingw-w64-x86_64-libmodplug
-          mingw-w64-x86_64-libopenmpt
-          mingw-w64-x86_64-libsamplerate
-          mingw-w64-x86_64-libsidplayfp
-          mingw-w64-x86_64-libsoxr
-          mingw-w64-x86_64-libvorbis
-          mingw-w64-x86_64-meson
-          mingw-w64-x86_64-mpg123
-          mingw-w64-x86_64-neon
-          mingw-w64-x86_64-opusfile
-          mingw-w64-x86_64-pkg-config
-          mingw-w64-x86_64-qt6-base
-          mingw-w64-x86_64-qt6-svg
-          mingw-w64-x86_64-SDL2
-          mingw-w64-x86_64-wavpack
+          mingw-w64-ucrt-x86_64-autotools
+          mingw-w64-ucrt-x86_64-faad2
+          mingw-w64-ucrt-x86_64-ffmpeg
+          mingw-w64-ucrt-x86_64-flac
+          mingw-w64-ucrt-x86_64-fluidsynth
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-gtk2
+          mingw-w64-ucrt-x86_64-json-glib
+          mingw-w64-ucrt-x86_64-lame
+          mingw-w64-ucrt-x86_64-libbs2b
+          mingw-w64-ucrt-x86_64-libcdio-paranoia
+          mingw-w64-ucrt-x86_64-libcue
+          mingw-w64-ucrt-x86_64-libmodplug
+          mingw-w64-ucrt-x86_64-libopenmpt
+          mingw-w64-ucrt-x86_64-libsamplerate
+          mingw-w64-ucrt-x86_64-libsidplayfp
+          mingw-w64-ucrt-x86_64-libsoxr
+          mingw-w64-ucrt-x86_64-libvorbis
+          mingw-w64-ucrt-x86_64-meson
+          mingw-w64-ucrt-x86_64-mpg123
+          mingw-w64-ucrt-x86_64-neon
+          mingw-w64-ucrt-x86_64-opusfile
+          mingw-w64-ucrt-x86_64-pkg-config
+          mingw-w64-ucrt-x86_64-qt6-base
+          mingw-w64-ucrt-x86_64-qt6-svg
+          mingw-w64-ucrt-x86_64-SDL2
+          mingw-w64-ucrt-x86_64-wavpack


### PR DESCRIPTION
UCRT64 is meanwhile the recommended MSYS2 environment for Windows.
Visual Studio uses it by default since 2015.

See also:
- https://www.msys2.org/docs/environments/
- https://www.msys2.org/news/#2022-10-29-changing-the-default-environment-from-mingw64-to-ucrt6