### PR TITLE
opus: add support for RG tags again

### DIFF
--- a/src/opus/opus.cc
+++ b/src/opus/opus.cc
@@ -237,12 +237,13 @@ static bool update_replay_gain(OggOpusFile * opus_file,
             rg_info->album_peak = str_to_double(album_peak);
             rg_info->track_peak = str_to_double(track_peak);
         }
+        
+        AUDDBG("Album peak: %s (%f)\n", album_peak, rg_info->album_peak);
+        AUDDBG("Track peak: %s (%f)\n", track_peak, rg_info->track_peak);
     }
 
     AUDDBG("Album gain: %s (%f)\n", album_gain, rg_info->album_gain);
-    AUDDBG("Track gain: %s (%f)\n", track_gain, rg_info->track_gain);
-    AUDDBG("Album peak: %s (%f)\n", album_peak, rg_info->album_peak);
-    AUDDBG("Track peak: %s (%f)\n", track_peak, rg_info->track_peak);
+    AUDDBG("Track gain: %s (%f)\n", track_gain, rg_info->track_gain);    
 
     return true;
 }

--- a/src/opus/opus.cc
+++ b/src/opus/opus.cc
@@ -237,13 +237,13 @@ static bool update_replay_gain(OggOpusFile * opus_file,
             rg_info->album_peak = str_to_double(album_peak);
             rg_info->track_peak = str_to_double(track_peak);
         }
-        
+
         AUDDBG("Album peak: %s (%f)\n", album_peak, rg_info->album_peak);
         AUDDBG("Track peak: %s (%f)\n", track_peak, rg_info->track_peak);
     }
 
     AUDDBG("Album gain: %s (%f)\n", album_gain, rg_info->album_gain);
-    AUDDBG("Track gain: %s (%f)\n", track_gain, rg_info->track_gain);    
+    AUDDBG("Track gain: %s (%f)\n", track_gain, rg_info->track_gain);
 
     return true;
 }

--- a/src/opus/opus.cc
+++ b/src/opus/opus.cc
@@ -181,6 +181,15 @@ static bool update_replay_gain(OggOpusFile * opus_file,
 
     const char * album_gain = opus_tags_query(tags, "R128_ALBUM_GAIN", 0);
     const char * track_gain = opus_tags_query(tags, "R128_TRACK_GAIN", 0);
+    bool got_r128 = true;
+
+    /* try to read RG tags if R128 didn't work*/
+    if (!album_gain && !track_gain)
+    {
+        got_r128 = false;
+        album_gain = opus_tags_query(tags, "REPLAYGAIN_ALBUM_GAIN", 0);
+        track_gain = opus_tags_query(tags, "REPLAYGAIN_TRACK_GAIN", 0);        
+    }
 
     /* stop if we have no gain values */
     if (!album_gain && !track_gain)
@@ -192,14 +201,43 @@ static bool update_replay_gain(OggOpusFile * opus_file,
     if (!track_gain)
         track_gain = album_gain;
 
-    /* Q7.8 number to float .. 2^8 = 256 */
-    /* EBU-R128 (-23 LUFS) to RG 2.0 (-18 LUFS) .. +5 dB */
-    rg_info->album_gain = str_to_double(album_gain) / 256 + 5.0f;
-    rg_info->track_gain = str_to_double(track_gain) / 256 + 5.0f;
+    if (got_r128)
+    {
+        /* Q7.8 number to float .. 2^8 = 256 */
+        /* EBU-R128 (-23 LUFS) to RG 2.0 (-18 LUFS) .. +5 dB */
+        rg_info->album_gain = str_to_double(album_gain) / 256 + 5.0f;
+        rg_info->track_gain = str_to_double(track_gain) / 256 + 5.0f;
 
-    /* Opus intentionally does not support peak tags */
-    rg_info->album_peak = 0;
-    rg_info->track_peak = 0;
+        /* Opus intentionally does not support peak tags */
+        rg_info->album_peak = 0;
+        rg_info->track_peak = 0;
+    }
+    else
+    {
+        rg_info->album_gain = str_to_double(album_gain);
+        rg_info->track_gain = str_to_double(track_gain);
+
+        const char * album_peak = opus_tags_query(tags, "REPLAYGAIN_ALBUM_PEAK", 0);
+        const char * track_peak = opus_tags_query(tags, "REPLAYGAIN_TRACK_PEAK", 0);
+
+        if (!album_peak && !track_peak)
+        {
+            /* okay, we have gain but no peak values */
+            rg_info->album_peak = 0;
+            rg_info->track_peak = 0;
+        }
+        else
+        {
+            /* fill in missing values if we can */
+            if (!album_peak)
+                album_peak = track_peak;
+            if (!track_peak)
+                track_peak = album_peak;
+
+            rg_info->album_peak = str_to_double(album_peak);
+            rg_info->track_peak = str_to_double(track_peak);
+        }
+    }
 
     AUDDBG("Album gain: %s (%f)\n", album_gain, rg_info->album_gain);
     AUDDBG("Track gain: %s (%f)\n", track_gain, rg_info->track_gain);

--- a/src/opus/opus.cc
+++ b/src/opus/opus.cc
@@ -186,9 +186,9 @@ static bool update_replay_gain(OggOpusFile * opus_file,
 
     /* try to read RG tags if R128 didn't work */
     if (!has_r128_tags)
-    {        
+    {
         album_gain = opus_tags_query(tags, "REPLAYGAIN_ALBUM_GAIN", 0);
-        track_gain = opus_tags_query(tags, "REPLAYGAIN_TRACK_GAIN", 0);        
+        track_gain = opus_tags_query(tags, "REPLAYGAIN_TRACK_GAIN", 0);
     }
 
     /* stop if we have no gain values */

--- a/src/opus/opus.cc
+++ b/src/opus/opus.cc
@@ -179,14 +179,14 @@ static bool update_replay_gain(OggOpusFile * opus_file,
     if (!tags)
         return false;
 
+    /* try to read R128 tags */
     const char * album_gain = opus_tags_query(tags, "R128_ALBUM_GAIN", 0);
     const char * track_gain = opus_tags_query(tags, "R128_TRACK_GAIN", 0);
-    bool got_r128 = true;
+    bool has_r128_tags = (album_gain || track_gain);
 
-    /* try to read RG tags if R128 didn't work*/
-    if (!album_gain && !track_gain)
-    {
-        got_r128 = false;
+    /* try to read RG tags if R128 didn't work */
+    if (!has_r128_tags)
+    {        
         album_gain = opus_tags_query(tags, "REPLAYGAIN_ALBUM_GAIN", 0);
         track_gain = opus_tags_query(tags, "REPLAYGAIN_TRACK_GAIN", 0);        
     }
@@ -201,7 +201,7 @@ static bool update_replay_gain(OggOpusFile * opus_file,
     if (!track_gain)
         track_gain = album_gain;
 
-    if (got_r128)
+    if (has_r128_tags)
     {
         /* Q7.8 number to float .. 2^8 = 256 */
         /* EBU-R128 (-23 LUFS) to RG 2.0 (-18 LUFS) .. +5 dB */
@@ -241,6 +241,8 @@ static bool update_replay_gain(OggOpusFile * opus_file,
 
     AUDDBG("Album gain: %s (%f)\n", album_gain, rg_info->album_gain);
     AUDDBG("Track gain: %s (%f)\n", track_gain, rg_info->track_gain);
+    AUDDBG("Album peak: %s (%f)\n", album_peak, rg_info->album_peak);
+    AUDDBG("Track peak: %s (%f)\n", track_peak, rg_info->track_peak);
 
     return true;
 }


### PR DESCRIPTION
Re-added Thomas's original RG code and some logic to support both R128 and RG, while preferring R128.