### PR TITLE
Make UI appear on Qt::ApplicationActive for MacOS

### DIFF
--- a/src/qtui/main_window.cc
+++ b/src/qtui/main_window.cc
@@ -21,6 +21,7 @@
 
 #include <libaudcore/drct.h>
 #include <libaudcore/i18n.h>
+#include <libaudcore/interface.h>
 #include <libaudcore/plugins.h>
 #include <libaudcore/runtime.h>
 
@@ -221,7 +222,16 @@ MainWindow::MainWindow()
 
     /* set initial keyboard focus on the playlist */
     m_playlist_tabs->currentPlaylistWidget()->setFocus(Qt::OtherFocusReason);
+
+#ifdef Q_OS_MAC
+    QObject::connect(qGuiApp, &QGuiApplication::applicationStateChanged, this, [](auto state){
+        if (state == Qt::ApplicationState::ApplicationActive) {
+            aud_ui_show(true);
+        }
+    });
+#endif
 }
+
 
 MainWindow::~MainWindow()
 {

--- a/src/qtui/main_window.cc
+++ b/src/qtui/main_window.cc
@@ -39,6 +39,7 @@
 #include <QBoxLayout>
 #include <QCloseEvent>
 #include <QDockWidget>
+#include <QGuiApplication>
 #include <QLabel>
 #include <QMenuBar>
 #include <QSettings>
@@ -224,14 +225,12 @@ MainWindow::MainWindow()
     m_playlist_tabs->currentPlaylistWidget()->setFocus(Qt::OtherFocusReason);
 
 #ifdef Q_OS_MAC
-    QObject::connect(qGuiApp, &QGuiApplication::applicationStateChanged, this, [](auto state){
-        if (state == Qt::ApplicationState::ApplicationActive) {
+    QObject::connect(qGuiApp, &QGuiApplication::applicationStateChanged, this, [](auto state) {
+        if (state == Qt::ApplicationState::ApplicationActive)
             aud_ui_show(true);
-        }
     });
 #endif
 }
-
 
 MainWindow::~MainWindow()
 {


### PR DESCRIPTION
If the status icon plugin is used with close to system tray the UI main window is closed. On Mac OS there is not an easy way to make it reappear. The system tray activation trigger is disabled on Mac OS. This is for good reason due to one button mouse support and that this usually is intended to open the status/tray menu. Instead we can handle the application state change activate signal which will fire when the dock icon is clicked.