### PR TITLE
Revert "qtui: Make UI appear on Qt::ApplicationActive for macOS"

### DIFF
--- a/src/qtui/main_window.cc
+++ b/src/qtui/main_window.cc
@@ -21,7 +21,6 @@
 
 #include <libaudcore/drct.h>
 #include <libaudcore/i18n.h>
-#include <libaudcore/interface.h>
 #include <libaudcore/plugins.h>
 #include <libaudcore/runtime.h>
 
@@ -39,7 +38,6 @@
 #include <QBoxLayout>
 #include <QCloseEvent>
 #include <QDockWidget>
-#include <QGuiApplication>
 #include <QLabel>
 #include <QMenuBar>
 #include <QSettings>
@@ -223,13 +221,6 @@ MainWindow::MainWindow()
 
     /* set initial keyboard focus on the playlist */
     m_playlist_tabs->currentPlaylistWidget()->setFocus(Qt::OtherFocusReason);
-
-#ifdef Q_OS_MAC
-    QObject::connect(qGuiApp, &QGuiApplication::applicationStateChanged, this, [](auto state) {
-        if (state == Qt::ApplicationState::ApplicationActive)
-            aud_ui_show(true);
-    });
-#endif
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
This reverts commit 2f2d5374f0f8ec7f453e37d821f2687a5a36dc25 from #174 
Better to handle this in libaudqt directly on the QApplication so that it is main window/skin agnostic.

See audacious-media-player/audacious#1523.