### PR TITLE
mpris2: fix build on CYGWIN

### DIFF
--- a/src/mpris2/plugin.cc
+++ b/src/mpris2/plugin.cc
@@ -19,6 +19,7 @@
 
 #include <math.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <libaudcore/audstrings.h>
 #include <libaudcore/drct.h>


### PR DESCRIPTION
I updated the packages of audacious and audacious-plugins to 4.4.2 but I got a tiny error at compile time with mpris2 plugin.
This was the message printed on the console:
```
../src/mpris2/plugin.cc: In function ‘void add_g_variant_str(const char*, const char*, Index<_GVariant*>&)’: ../src/mpris2/plugin.cc:112:24: error: ‘strlen’ was not declared in this scope
  112 |     if (! value_str || strlen (value_str) == 0)
      |                        ^~~~~~
../src/mpris2/plugin.cc:35:1: note: ‘strlen’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
   34 | #include "object-player.h"
  +++ |+#include <cstring>
   35 |
```
I did the suggestion from GCC and I added `string.h` near the other include files: after that, the build process completed successfully.
No other corrections were needed for making my new packages for CYGWIN.