### PR TITLE
Fix track length for CUE files specifying "INDEX 00" pregap

### DIFF
--- a/src/cue/cue.cc
+++ b/src/cue/cue.cc
@@ -161,9 +161,9 @@ bool CueLoader::load (const char * cue_filename, VFSFile & file, String & title,
 
             if (same_file)
             {
-                int len = (int64_t) track_get_length (cur) * 1000 / 75;
-                tuple.set_int (Tuple::EndTime, begin + len);
-                tuple.set_int (Tuple::Length, len);
+                int length = (int64_t) track_get_length (cur) * 1000 / 75;
+                tuple.set_int (Tuple::EndTime, begin + length);
+                tuple.set_int (Tuple::Length, length);
             }
             else
             {

--- a/src/cue/cue.cc
+++ b/src/cue/cue.cc
@@ -161,9 +161,9 @@ bool CueLoader::load (const char * cue_filename, VFSFile & file, String & title,
 
             if (same_file)
             {
-                int end = (int64_t) track_get_start (next) * 1000 / 75;
-                tuple.set_int (Tuple::EndTime, end);
-                tuple.set_int (Tuple::Length, end - begin);
+                int len = (int64_t) track_get_length (cur) * 1000 / 75;
+                tuple.set_int (Tuple::EndTime, begin + len);
+                tuple.set_int (Tuple::Length, len);
             }
             else
             {


### PR DESCRIPTION
A followup to issue #1538. Libcue takes over calculating the correct track length under consideration of any pregap.