### PR TITLE
gl-spectrum: Add modern GL renderer and GtkGLArea support

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -29,12 +29,14 @@ runs:
           mingw-w64-ucrt-x86_64-flac
           mingw-w64-ucrt-x86_64-fluidsynth
           mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-glm
           mingw-w64-ucrt-x86_64-gtk2
           mingw-w64-ucrt-x86_64-json-glib
           mingw-w64-ucrt-x86_64-lame
           mingw-w64-ucrt-x86_64-libbs2b
           mingw-w64-ucrt-x86_64-libcdio-paranoia
           mingw-w64-ucrt-x86_64-libcue
+          mingw-w64-ucrt-x86_64-libepoxy
           mingw-w64-ucrt-x86_64-libmodplug
           mingw-w64-ucrt-x86_64-libopenmpt
           mingw-w64-ucrt-x86_64-libsamplerate

--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -24,14 +24,16 @@ ubuntu_packages='gettext libadplug-dev libasound2-dev libavformat-dev
                  libmpg123-dev libneon27-gnutls-dev libnotify-dev libopenmpt-dev
                  libopusfile-dev libpipewire-0.3-dev libpulse-dev
                  libsamplerate0-dev libsdl2-dev libsidplayfp-dev libsndfile1-dev
-                 libsndio-dev libsoxr-dev libvorbis-dev libwavpack-dev libxml2-dev'
+                 libsndio-dev libsoxr-dev libvorbis-dev libwavpack-dev libxml2-dev
+                 libepoxy-dev libglm-dev'
 
 ubuntu_qt5_packages='libqt5opengl5-dev libqt5svg5-dev libqt5x11extras5-dev
                      qtbase5-dev qtmultimedia5-dev'
 ubuntu_qt6_packages='qt6-base-dev qt6-multimedia-dev qt6-svg-dev'
 
 macos_packages='adplug faad2 ffmpeg libbs2b libcue libmms libmodplug libnotify
-                libopenmpt libsamplerate libsoxr neon opusfile sdl3 wavpack'
+                libopenmpt libsamplerate libsoxr neon opusfile sdl3 wavpack
+                libepoxy glm'
 
 case "$os" in
   ubuntu-22.04)

--- a/config.h.meson
+++ b/config.h.meson
@@ -20,6 +20,8 @@
 #mesondefine USE_QT
 #mesondefine USE_GTK
 #mesondefine USE_GTK3
+#mesondefine USE_GTKGLAREA
+#mesondefine USE_MODERNGL
 #mesondefine USE_GTK_OR_QT
 
 #define GLIB_VERSION_MIN_REQUIRED GLIB_VERSION_2_32

--- a/configure.ac
+++ b/configure.ac
@@ -495,18 +495,36 @@ dnl Optional plugins (GTK-only)
 dnl ===========================
 
 test_glspectrum () {
-    if test $HAVE_DARWIN = yes ; then
+    PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.16], [have_gtk_3_16=yes], [have_gtk_3_16=no])
+    PKG_CHECK_MODULES(EPOXY, epoxy, [have_epoxy=yes], [have_epoxy=no])
+    AC_LANG_PUSH([C++])
+    AC_CHECK_HEADER([glm/glm.hpp], [have_glm=yes], [have_glm=no])
+    AC_LANG_POP([C++])
+
+    GL_LIBS=""
+
+    if test $have_glm = yes && test $have_epoxy = yes ; then
+        GL_LIBS="$EPOXY_LIBS"
+        AC_DEFINE(USE_MODERNGL, [1], [Define if Modern GL should be used])
+    fi
+
+    if test "x$USE_MODERNGL" = "xyes" && test "x$USE_GTK2" = "xno" && test $have_gtk_3_16 = yes ; then
+        have_glspectrum=yes
+        GL_LIBS="$GL_LIBS -lGL"
+        AC_DEFINE(USE_GTKGLAREA, [1], [Define if GtkGLArea should be used])
+    elif test $HAVE_DARWIN = yes ; then
         have_glspectrum=no
     elif test $HAVE_MSWINDOWS = yes ; then
         have_glspectrum=yes
-        GL_LIBS="-lopengl32"
+        GL_LIBS="$GL_LIBS -lopengl32"
     else
         AC_CHECK_LIB(GL, glXCreateContext, [
             have_glspectrum=yes
-            GL_LIBS="-lGL -lX11"
+            GL_LIBS="$GL_LIBS -lGL -lX11"
         ], [have_glspectrum=no])
     fi
     AC_SUBST(GL_LIBS)
+    AC_SUBST(GL_CFLAGS, [$EPOXY_CFLAGS])
 }
 
 ENABLE_PLUGIN_WITH_TEST(glspectrum,

--- a/configure.ac
+++ b/configure.ac
@@ -495,7 +495,6 @@ dnl Optional plugins (GTK-only)
 dnl ===========================
 
 test_glspectrum () {
-    PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.16], [have_gtk_3_16=yes], [have_gtk_3_16=no])
     PKG_CHECK_MODULES(EPOXY, epoxy, [have_epoxy=yes], [have_epoxy=no])
     AC_LANG_PUSH([C++])
     AC_CHECK_HEADER([glm/glm.hpp], [have_glm=yes], [have_glm=no])
@@ -508,7 +507,7 @@ test_glspectrum () {
         AC_DEFINE(USE_MODERNGL, [1], [Define if Modern GL should be used])
     fi
 
-    if test "x$USE_MODERNGL" = "xyes" && test "x$USE_GTK2" = "xno" && test $have_gtk_3_16 = yes ; then
+    if test "x$USE_MODERNGL" = "xyes" && test "x$USE_GTK2" = "xno" ; then
         have_glspectrum=yes
         GL_LIBS="$GL_LIBS -lGL"
         AC_DEFINE(USE_GTKGLAREA, [1], [Define if GtkGLArea should be used])

--- a/src/glspectrum/Makefile
+++ b/src/glspectrum/Makefile
@@ -1,6 +1,6 @@
 PLUGIN = gl-spectrum${PLUGIN_SUFFIX}
 
-SRCS = gl-spectrum.cc
+SRCS = gl-spectrum.cc modern_renderer.cc
 
 include ../../buildsys.mk
 include ../../extra.mk
@@ -8,6 +8,6 @@ include ../../extra.mk
 plugindir := ${plugindir}/${VISUALIZATION_PLUGIN_DIR}
 
 LD = ${CXX}
-CFLAGS += ${PLUGIN_CFLAGS}
+CFLAGS += ${PLUGIN_CFLAGS} ${GL_CFLAGS}
 CPPFLAGS += ${PLUGIN_CPPFLAGS} -I../.. ${GTK_CFLAGS}
 LIBS += -lm ${GTK_LIBS} ${GL_LIBS}

--- a/src/glspectrum/meson.build
+++ b/src/glspectrum/meson.build
@@ -1,11 +1,26 @@
 opengl_dep = dependency('GL', required: false)
-have_glspectrum = opengl_dep.found() and (have_windows or x11_dep.found())
+epoxy_dep = dependency('epoxy', required: false)
+glm_dep = dependency('glm', required: false)
 
+if epoxy_dep.found() and glm_dep.found()
+  conf.set10('USE_MODERNGL', true)
+endif
+
+if conf.has('USE_GTK3') and gtk_dep.version() >= '3.16' and \
+    conf.has('USE_MODERNGL')
+  conf.set10('USE_GTKGLAREA', true)
+endif
+
+have_glspectrum = opengl_dep.found() and (
+    (have_windows or x11_dep.found()) or
+    conf.has('USE_GTKGLAREA')
+)
 
 if have_glspectrum
   shared_module('gl-spectrum',
-    'gl-spectrum.cc',
-    dependencies: [audacious_dep, math_dep, gtk_dep, opengl_dep, x11_dep],
+    'gl-spectrum.cc', 'modern_renderer.cc',
+    dependencies: [audacious_dep, math_dep, gtk_dep, opengl_dep, x11_dep,
+                   epoxy_dep, glm_dep],
     name_prefix: '',
     install: true,
     install_dir: visualization_plugin_dir

--- a/src/glspectrum/meson.build
+++ b/src/glspectrum/meson.build
@@ -6,8 +6,7 @@ if epoxy_dep.found() and glm_dep.found()
   conf.set10('USE_MODERNGL', true)
 endif
 
-if conf.has('USE_GTK3') and gtk_dep.version() >= '3.16' and \
-    conf.has('USE_MODERNGL')
+if conf.has('USE_GTK3') and conf.has('USE_MODERNGL')
   conf.set10('USE_GTKGLAREA', true)
 endif
 

--- a/src/glspectrum/modern_renderer.cc
+++ b/src/glspectrum/modern_renderer.cc
@@ -1,0 +1,488 @@
+#include "modern_renderer.h"
+
+/* We don't want this to be built without USE_MODERNGL */
+#ifdef USE_MODERNGL
+
+#include <vector>
+
+#include <glib.h>
+
+#include <libaudcore/runtime.h>
+
+#include <epoxy/gl.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+const char* vertex_shader_src =
+R"(#version ${version_string}
+
+in vec3 position;
+in vec3 color;
+in int id;
+
+uniform int s_pos;
+uniform mat4 mvp;
+uniform sampler2D s_bars;
+
+out vec4 vertexColor;
+
+void main()
+{
+    ivec2 texture_size = textureSize (s_bars, 0);
+
+    vec2 uv = vec2
+    (
+        mod (float (id), ${num_bands}.0) + 0.5,
+        mod (float ((id / ${num_bands}) + s_pos), ${num_bands}.0) + 0.5
+    );
+
+    float height = texture (s_bars, uv / ${num_bands}.0).r * 1.6;
+
+    gl_Position = mvp * vec4 (position.x, position.y * height, position.z, 1.0);
+    vertexColor = vec4 (color * (0.2 + 0.8 * height), 1.0);
+}
+)";
+
+const char* fragment_shader_src =
+R"(#version ${version_string}
+
+precision mediump float;
+in vec4 vertexColor;
+
+out vec4 outputColor;
+
+void main() {
+    outputColor = vertexColor;
+}
+)";
+
+struct vertex
+{
+    GLfloat position[3];
+    GLfloat color[3];
+
+    /* If -1 the Y coordinate will be 0, otherwise it'll be used to index the
+     * texture */
+    GLint id;
+};
+
+struct triangle
+{
+    vertex position[3];
+};
+
+static GLuint
+create_shader (int shader_type, const char * source, GLuint * shader_out)
+{
+    GLuint shader = glCreateShader (shader_type);
+    glShaderSource (shader, 1, &source, NULL);
+    glCompileShader (shader);
+
+    int status;
+    glGetShaderiv (shader, GL_COMPILE_STATUS, &status);
+    if (status == GL_FALSE)
+    {
+        int log_len;
+        glGetShaderiv (shader, GL_INFO_LOG_LENGTH, &log_len);
+
+        char *buffer = new char[log_len + 1];
+        glGetShaderInfoLog (shader, log_len, NULL, buffer);
+
+        AUDERR
+        (
+            "%s shader compilation error:%s\n",
+            (shader_type == GL_VERTEX_SHADER ? "Vertex" : "Fragment"),
+            buffer
+        );
+
+        delete [] buffer;
+
+        glDeleteShader (shader);
+        shader = 0;
+    }
+
+    if (shader_out != NULL)
+        *shader_out = shader;
+
+    return shader != 0;
+}
+
+bool ModernRenderer::init_shaders ()
+{
+    GLuint program = 0;
+    GLuint vertex = 0;
+    GLuint fragment = 0;
+
+    bool es = !epoxy_is_desktop_gl ();
+
+    const gchar * version_str = es ? "300 es" : "130";
+
+    AUDINFO
+    (
+       "Detected OpenGL type: %s, using GLSL version string: %s\n",
+       es ? "GLES" : "GL",
+       version_str
+    );
+
+    GString * vertex_shader_string = g_string_new (vertex_shader_src);
+
+    g_string_replace (vertex_shader_string,
+                      "${version_string}",
+                      version_str,
+                      0);
+
+    g_string_replace (vertex_shader_string,
+                      "${num_bands}",
+                      g_strdup_printf("%i", NUM_BANDS),
+                      0);
+
+    create_shader (GL_VERTEX_SHADER, vertex_shader_string->str, &vertex);
+
+    g_free(vertex_shader_string);
+
+    GString * fragment_shader_string = g_string_new (fragment_shader_src);
+
+    g_string_replace(fragment_shader_string,
+                     "${version_string}",
+                     version_str,
+                     0);
+
+    create_shader (GL_FRAGMENT_SHADER, fragment_shader_string->str, &fragment);
+
+    g_free(fragment_shader_string);
+
+    GLuint mvp_pointer = 0;
+    GLuint s_pos_pointer = 0;
+
+    if (vertex != 0 && fragment != 0)
+    {
+        /* link the vertex and fragment shaders together */
+        program = glCreateProgram ();
+        glAttachShader (program, vertex);
+        glAttachShader (program, fragment);
+        glLinkProgram (program);
+
+        int status = GL_FALSE;
+
+        glGetProgramiv (program, GL_LINK_STATUS, &status);
+
+        if (status)
+        {
+            mvp_pointer = glGetUniformLocation (program, "mvp");
+            s_pos_pointer = glGetUniformLocation (program, "s_pos");
+
+            /* the individual shaders can be detached and destroyed */
+            glDetachShader (program, vertex);
+            glDetachShader (program, fragment);
+        }
+        else
+        {
+            int log_len = 0;
+            glGetProgramiv (program, GL_INFO_LOG_LENGTH, &log_len);
+
+            char *buffer = new char[log_len + 1];
+            glGetProgramInfoLog (program, log_len, NULL, buffer);
+
+            AUDERR ("Linking failure in program: %s\n", buffer);
+
+            delete [] buffer;
+
+            glDeleteProgram (program);
+            program = 0;
+        }
+    }
+
+    if (vertex != 0)
+        glDeleteShader (vertex);
+
+    if (fragment != 0)
+        glDeleteShader (fragment);
+
+    if (program != 0)
+    {
+        ModernRenderer::program = program;
+        ModernRenderer::mvp_pointer = mvp_pointer;
+        ModernRenderer::s_pos_pointer = s_pos_pointer;
+    }
+
+    return program != 0;
+}
+
+void
+ModernRenderer::update_vbo (const triangle * triangle_buffer,
+                            int triangle_count)
+{
+    GLuint position_pointer = glGetAttribLocation (program, "position");
+    GLuint color_pointer    = glGetAttribLocation (program, "color");
+    GLuint id_pointer       = glGetAttribLocation (program, "id");
+
+    GLuint vbo;
+
+    glGenBuffers (1, &vbo);
+
+    glBindVertexArray (vao);
+
+    glBindBuffer (GL_ARRAY_BUFFER, vbo);
+    glBufferData
+    (
+        GL_ARRAY_BUFFER,
+        sizeof (struct triangle) * triangle_count,
+        triangle_buffer,
+        GL_STATIC_DRAW
+    );
+
+    /* enable and set the position attribute */
+    glEnableVertexAttribArray (position_pointer);
+    glVertexAttribPointer
+    (
+        position_pointer,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        sizeof (struct vertex),
+        (GLvoid *) (G_STRUCT_OFFSET (struct vertex, position))
+    );
+
+    /* enable and set the color attribute */
+    glEnableVertexAttribArray (color_pointer);
+    glVertexAttribPointer (
+        color_pointer,
+        3,
+        GL_FLOAT,
+        GL_FALSE,
+        sizeof (struct vertex),
+        (GLvoid *) (G_STRUCT_OFFSET (struct vertex, color))
+    );
+
+    /* enable and set the id attribute */
+    glEnableVertexAttribArray (id_pointer);
+    glVertexAttribIPointer (
+    id_pointer,
+        1,
+        GL_INT,
+        sizeof (struct vertex),
+        (GLvoid *) (G_STRUCT_OFFSET (struct vertex, id))
+    );
+
+    glBindBuffer (GL_ARRAY_BUFFER, 0);
+    glBindVertexArray (0);
+
+    /* the VBO is referenced by the VAO */
+    glDeleteBuffers (1, &vbo);
+}
+
+static void add_rectangle (std::vector<triangle> * triangle_buffer, int id,
+                           float x1, float z1, float x2, float z2,
+                           float r, float g, float b)
+{
+    /* All triangle vertices should be aligned counter-clockwise */
+
+    /* height multiplier */
+    float h_mu = 1.0f;
+
+    /* Top */
+    triangle_buffer->push_back
+    ({
+        vertex{ { x2, h_mu, z2 }, { r, g, b }, id },
+        vertex{ { x2, h_mu, z1 }, { r, g, b }, id },
+        vertex{ { x1, h_mu, z1 }, { r, g, b }, id },
+    });
+
+    triangle_buffer->push_back
+    ({
+        vertex{ { x1, h_mu, z2 }, { r, g, b }, id },
+        vertex{ { x2, h_mu, z2 }, { r, g, b }, id },
+        vertex{ { x1, h_mu, z1 }, { r, g, b }, id },
+    });
+
+    /* Right */
+    triangle_buffer->push_back
+    ({
+        vertex{ { x1, h_mu, z2 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x1, h_mu, z1 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x1, 0.0f, z1 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+    });
+
+    triangle_buffer->push_back
+    ({
+        vertex{ { x1, 0.0f, z2 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x1, h_mu, z2 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x1, 0.0f, z1 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+    });
+
+    /* Left */
+    triangle_buffer->push_back
+    ({
+        vertex{ { x2, 0.0f, z2 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x2, 0.0f, z1 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x2, h_mu, z1 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+    });
+
+    triangle_buffer->push_back
+    ({
+        vertex{ { x2, h_mu, z2 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x2, 0.0f, z2 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+        vertex{ { x2, h_mu, z1 }, { 0.65f * r, 0.65f * g, 0.65f * b }, id },
+    });
+
+    /* Front */
+    triangle_buffer->push_back
+    ({
+        vertex{ { x2, h_mu, z1 }, { 0.8f * r, 0.8f * g, 0.8f * b }, id },
+        vertex{ { x2, 0.0f, z1 }, { 0.8f * r, 0.8f * g, 0.8f * b }, id },
+        vertex{ { x1, 0.0f, z1 }, { 0.8f * r, 0.8f * g, 0.8f * b }, id },
+    });
+
+    triangle_buffer->push_back
+    ({
+        vertex{ { x1, h_mu, z1 }, { 0.8f * r, 0.8f * g, 0.8f * b }, id },
+        vertex{ { x2, h_mu, z1 }, { 0.8f * r, 0.8f * g, 0.8f * b }, id },
+        vertex{ { x1, 0.0f, z1 }, { 0.8f * r, 0.8f * g, 0.8f * b }, id },
+    });
+}
+
+void
+ModernRenderer::add_bars (std::vector<triangle> * triangle_buffer,
+                          const float * colors)
+{
+    for (int i = 0; i < NUM_BANDS; i ++)
+    {
+        for (int j = 0; j < NUM_BANDS; j ++)
+        {
+            float x = 1.6f - BAR_SPACING * j;
+            float z = -1.6f + (NUM_BANDS - i) * BAR_SPACING;
+
+            int id = (i % NUM_BANDS) * NUM_BANDS + j;
+
+            float r = colors[id * 3 + 0];
+            float g = colors[id * 3 + 1];
+            float b = colors[id * 3 + 2];
+
+            add_rectangle
+            (
+                triangle_buffer,
+                id,
+                x, z,
+                x + BAR_WIDTH, z + BAR_WIDTH,
+                r, g, b
+            );
+        }
+    }
+}
+
+ModernRenderer::ModernRenderer (
+    int num_bands,
+    float bar_spacing,
+    float bar_width,
+    const float * colors
+) : NUM_BANDS (num_bands),
+    BAR_SPACING (bar_spacing),
+    BAR_WIDTH (bar_width),
+    projection (glm::frustum (-1.1f, 1.0f, -1.5f, 1.0f, 2.0f, 10.0f))
+{
+    int gl_version = epoxy_gl_version();
+    bool has_ext = epoxy_has_gl_extension ("GL_ARB_vertex_array_object");
+
+    AUDINFO
+    (
+        "OpenGL version %d, %s GL_ARB_vertex_array_object.\n",
+        gl_version,
+        has_ext ? "has" : "doesn't have"
+    );
+
+    if (gl_version < 21 || !has_ext)
+    {
+        return;
+    }
+
+    if (!init_shaders ())
+    {
+        return;
+    }
+
+    glGenVertexArrays (1, &vao);
+
+    std::vector<triangle> triangle_buffer;
+
+    /* We need upload the geometry data only once */
+    add_bars (&triangle_buffer, colors);
+    update_vbo (triangle_buffer.data (), triangle_buffer.size ());
+
+    triangle_count = triangle_buffer.size ();
+
+    glGenTextures (1, &values_tex);
+    glBindTexture (GL_TEXTURE_2D, values_tex);
+
+    glEnable (GL_TEXTURE);
+    glEnable (GL_DEPTH_TEST);
+    glDisable (GL_CULL_FACE);
+
+    glClearColor (0, 0, 0, 1);
+
+    initialized = true;
+}
+
+void
+ModernRenderer::render (const float * s_bars, int s_pos, float s_angle)
+{
+    glUseProgram (program);
+
+    glm::mat4 model = glm::mat4 (1.0f);
+    model = glm::translate (model, glm::vec3 (0.0f, -0.5f, -5.0f));
+
+    model = glm::rotate (model,
+        glm::radians (38.0f), glm::vec3 (1.0f, 0.0f, 0.0f));
+
+    model = glm::rotate (model,
+        glm::radians (s_angle + 180.0f), glm::vec3 (0.0f, 1.0f, 0.0f));
+
+    glm::mat4 mvp = projection * model;
+
+    glUniformMatrix4fv (mvp_pointer, 1, GL_FALSE, glm::value_ptr (mvp));
+    glUniform1i (s_pos_pointer, s_pos);
+
+    /* Upload our array as an OpenGL texture */
+    glTexImage2D
+    (
+        GL_TEXTURE_2D,
+        0,
+        GL_R32F,
+        NUM_BANDS, NUM_BANDS,
+        0,
+        GL_RED,
+        GL_FLOAT,
+        s_bars
+    );
+
+    glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+
+    glBindVertexArray (vao);
+
+    glDrawArrays (GL_TRIANGLES, 0, triangle_count * 3);
+
+    glBindVertexArray (0);
+    glUseProgram (0);
+}
+
+bool ModernRenderer::is_initialized () const
+{
+    return initialized;
+}
+
+ModernRenderer::~ModernRenderer ()
+{
+    if (values_tex)
+        glDeleteTextures (1, &values_tex);
+
+    if (vao)
+        glDeleteVertexArrays (1, &vao);
+
+    if (program)
+        glDeleteProgram (program);
+}
+
+#endif // USE_MODERNGL

--- a/src/glspectrum/modern_renderer.cc
+++ b/src/glspectrum/modern_renderer.cc
@@ -20,7 +20,7 @@ R"(#version ${version_string}
 
 in vec3 position;
 in vec3 color;
-in int id;
+in float id;
 
 uniform int s_pos;
 uniform mat4 mvp;
@@ -32,8 +32,8 @@ void main()
 {
     vec2 uv = vec2
     (
-        mod (float (id), ${num_bands}.0) + 0.5,
-        mod (float ((id / ${num_bands}) + s_pos), ${num_bands}.0) + 0.5
+        mod (id, ${num_bands}.0) + 0.5,
+        mod (float ((int (id) / ${num_bands}) + s_pos), ${num_bands}.0) + 0.5
     );
 
     float height = texture2D (s_bars, uv / ${num_bands}.0).r * 1.6;
@@ -256,10 +256,11 @@ ModernRenderer::update_vbo (const triangle * triangle_buffer,
 
     /* enable and set the id attribute */
     glEnableVertexAttribArray (id_pointer);
-    glVertexAttribIPointer (
+    glVertexAttribPointer (
     id_pointer,
         1,
         GL_INT,
+        GL_FALSE,
         sizeof (struct vertex),
         (GLvoid *) (G_STRUCT_OFFSET (struct vertex, id))
     );

--- a/src/glspectrum/modern_renderer.cc
+++ b/src/glspectrum/modern_renderer.cc
@@ -417,7 +417,7 @@ ModernRenderer::ModernRenderer (
 
     glEnable (GL_TEXTURE);
     glEnable (GL_DEPTH_TEST);
-    glDisable (GL_CULL_FACE);
+    glEnable (GL_CULL_FACE);
 
     glClearColor (0, 0, 0, 1);
 

--- a/src/glspectrum/modern_renderer.cc
+++ b/src/glspectrum/modern_renderer.cc
@@ -390,7 +390,7 @@ ModernRenderer::ModernRenderer (
         has_ext ? "has" : "doesn't have"
     );
 
-    if (!(gl_version > 30 || (gl_version > 21 && has_ext)))
+    if (!(gl_version >= 30 || (gl_version >= 21 && has_ext)))
     {
         return;
     }

--- a/src/glspectrum/modern_renderer.cc
+++ b/src/glspectrum/modern_renderer.cc
@@ -26,7 +26,7 @@ uniform int s_pos;
 uniform mat4 mvp;
 uniform sampler2D s_bars;
 
-out vec4 vertexColor;
+varying out vec4 vertexColor;
 
 void main()
 {
@@ -36,7 +36,7 @@ void main()
         mod (float ((id / ${num_bands}) + s_pos), ${num_bands}.0) + 0.5
     );
 
-    float height = texture (s_bars, uv / ${num_bands}.0).r * 1.6;
+    float height = texture2D (s_bars, uv / ${num_bands}.0).r * 1.6;
 
     gl_Position = mvp * vec4 (position.x, position.y * height, position.z, 1.0);
     vertexColor = vec4 (color * (0.2 + 0.8 * height), 1.0);
@@ -49,7 +49,7 @@ R"(#version ${version_string}
 precision mediump float;
 in vec4 vertexColor;
 
-out vec4 outputColor;
+varying out vec4 outputColor;
 
 void main() {
     outputColor = vertexColor;
@@ -115,7 +115,7 @@ bool ModernRenderer::init_shaders ()
 
     bool es = !epoxy_is_desktop_gl ();
 
-    const gchar * version_str = es ? "300 es" : "130";
+    const gchar * version_str = es ? "300 es" : "120";
 
     AUDINFO
     (

--- a/src/glspectrum/modern_renderer.cc
+++ b/src/glspectrum/modern_renderer.cc
@@ -390,7 +390,7 @@ ModernRenderer::ModernRenderer (
         has_ext ? "has" : "doesn't have"
     );
 
-    if (gl_version < 21 || !has_ext)
+    if (!(gl_version > 30 || (gl_version > 21 && has_ext)))
     {
         return;
     }

--- a/src/glspectrum/modern_renderer.cc
+++ b/src/glspectrum/modern_renderer.cc
@@ -30,8 +30,6 @@ out vec4 vertexColor;
 
 void main()
 {
-    ivec2 texture_size = textureSize (s_bars, 0);
-
     vec2 uv = vec2
     (
         mod (float (id), ${num_bands}.0) + 0.5,

--- a/src/glspectrum/modern_renderer.h
+++ b/src/glspectrum/modern_renderer.h
@@ -1,0 +1,48 @@
+#ifndef MODERN_RENDER_H
+#define MODERN_RENDER_H
+
+#include <vector>
+#include <glm/mat4x4.hpp>
+
+struct triangle;
+
+class ModernRenderer
+{
+public:
+    const int NUM_BANDS;
+    const float BAR_SPACING;
+    const float BAR_WIDTH;
+
+    explicit ModernRenderer
+    (
+        int num_bands,
+        float bar_spacing,
+        float bar_width,
+        const float * colors
+    );
+    ~ModernRenderer();
+
+    void render(const float * s_bars, int s_pos, float s_angle);
+    bool is_initialized() const;
+
+private:
+    unsigned int vao = 0;
+    unsigned int program = 0;
+    unsigned int values_tex = 0;
+
+    unsigned int mvp_pointer = 0;
+    unsigned int s_pos_pointer = 0;
+
+    glm::mat4 projection;
+
+    int triangle_count = 0;
+
+    bool initialized = false;
+
+    void add_bars (std::vector<triangle> * triangle_buffer,
+                   const float * colors);
+    void update_vbo (const triangle * triangle_buffer, int triangle_count);
+    bool init_shaders ();
+};
+
+#endif // MODERN_RENDER_H


### PR DESCRIPTION
Closes https://github.com/audacious-media-player/audacious/issues/1546

[![Video demonstration](https://img.youtube.com/vi/XhhnwEC9pWI/0.jpg)](https://www.youtube.com/watch?v=XhhnwEC9pWI)

AFAIU gl-spectrum plugin using GLX is one of the blockers for transitioning to using wayland by default. Well, not anymore, because I implemented GL context creation through GtkGLArea widget. Unfortunately, there are no good ways to force GtkGLArea to create a legacy GL context, it only falls back to legacy context if creating a core GL context failed, and this plugin used only legacy GL functions for rendering. So I implemented a new renderer which uses modern GL functions. The modern renderer is not uploading the whole scene to GPU on every frame like the legacy one does, but uploads it only once and then uploads only the height map on every frame, which is used calculate the actual geometry in a vertex shader, which should make it faster. The context version is being checked in runtime and the modern renderer is used if requirements are met, if not it's just using the old one. The modern renderer is also used by default in the case of context creation through GLX and Win32. If everything works fine, GLX and Win32 GL context creation code can be safely removed to reduce unnecessary complexity, and it won't change the minimal required OpenGL version as we can always fall back to the legacy rendering.

I also want to note that with the modern renderer cool effects can be added in the future. For now it's just replicating the old one.

Please test in on Windows and macOS before merging, as I can't verify if it's working there (it should).