### PR TITLE
opus: decode METADATA_BLOCK_PICTURE manually

### DIFF
--- a/src/opus/meson.build
+++ b/src/opus/meson.build
@@ -5,7 +5,7 @@ have_opus = opusfile_dep.found()
 if have_opus
   shared_module('opus',
     'opus.cc',
-    dependencies: [audacious_dep, opusfile_dep],
+    dependencies: [audacious_dep, opusfile_dep, glib_dep],
     name_prefix: '',
     include_directories: [src_inc],
     install: true,


### PR DESCRIPTION
I was trying to track down why Audacious was choking on thumbnails in some of my opus files.  It turns out the `libopusinfo` implementation of tag parsing is [strict about some of the fields](https://github.com/xiph/opusfile/blame/main/src/info.c#L655) in the `METADATA_BLOCK_PICTURE` and will return an error even if it contains a usable image.  Some common programs seem to write tags with this problem, and most applications that read thumbnails from Ogg containers (including the Audacious Vorbis plugin) seem to be lenient about it.  I therefore just copied the code over from the Vorbis plugin.