### PR TITLE
skins & skins-qt: visualizer rework

### DIFF
--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -32,7 +32,6 @@
 #include "vis.h"
 
 static const int svis_analyzer_colors[] = {14, 11, 8, 5, 2};
-static const int svis_scope_colors[] = {20, 19, 18, 19, 20};
 static const int svis_vu_normal_colors[] = {16, 14, 12, 10, 8, 6, 4, 2};
 
 #define RGB_SEEK(x,y) (set = rgb + 38 * (y) + (x))

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -26,6 +26,7 @@
 
 #include <string.h>
 #include <libaudcore/objects.h>
+#include <libaudcore/drct.h>
 
 #include "skins_cfg.h"
 #include "skin.h"
@@ -87,11 +88,12 @@ void SmallVis::draw (QPainter & cr)
                 int h = m_peak[bars ? (x / 3) : x];
                 h = aud::clamp (h, 0, 5);
 
-                if (h >= 5)
-                    continue;
-                RGB_SEEK (x, 4 - h);
-                RGB_SET_INDEX (23);
-
+                if (aud_drct_get_playing ()) {
+                    if (h >= 5)
+                        continue;
+                    RGB_SEEK (x, 4 - h);
+                    RGB_SET_INDEX (23);
+                }
             }
         }
 

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -106,7 +106,7 @@ void SmallVis::draw (QPainter & cr)
                 if (y == 2)
                     continue;
 
-                int h = (m_data[y / 3] * 8 + 19) / 38;
+                int h = (m_falloff[y / 3] * 8 + 19) / 38;
                 h = aud::clamp (h, 0, 8);
                 RGB_SEEK (0, y);
 
@@ -125,7 +125,7 @@ void SmallVis::draw (QPainter & cr)
                 if (y == 2)
                     continue;
 
-                int h = m_data[y / 3];
+                int h = m_falloff[y / 3];
                 h = aud::clamp (h, 0, 38);
                 RGB_SEEK (0, y);
 
@@ -258,8 +258,16 @@ void SmallVis::render (const unsigned char * data)
     }
     else if (config.vis_type == VIS_VOICEPRINT)
     {
-        for (int i = 0; i < 2; i ++)
+        for (int i = 0; i < 2; i ++) {
             m_data[i] = data[i];
+
+            m_falloff[i] -= vis_afalloff_speeds[config.analyzer_falloff];
+            if (m_falloff[i] <= m_data[i]){
+                m_falloff[i] = m_data[i];
+            }
+            if (m_falloff[i] < 0.0)
+                m_falloff[i] = 0.0;
+        }
     }
     else
     {

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -230,8 +230,8 @@ void SmallVis::render (const unsigned char * data)
         {
             m_data[i] = data[i];
 
-            if (m_falloff[i] >= 5.0){
-                m_falloff[i] = 5.0;
+            if (m_data[i] >= 5.0){
+                m_data[i] = 5.0;
             }
 
             m_falloff[i] -= vis_afalloff_speeds[config.analyzer_falloff] / 4;

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -55,7 +55,7 @@ void SmallVis::draw (QPainter & cr)
     {
         bool bars = (config.analyzer_type == ANALYZER_BARS);
 
-        for (int x = 0; x < 38; x ++)
+        for (int x = 0; x < 37; x ++)
         {
             if (bars && (x % 3) == 2)
                 continue;

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -31,7 +31,7 @@
 #include "skin.h"
 #include "vis.h"
 
-static const int svis_analyzer_colors[] = {14, 11, 8, 5, 2};
+static const int svis_analyzer_colors[] = {17, 14, 11, 8, 4};
 static const int svis_vu_normal_colors[] = {16, 14, 12, 10, 8, 6, 4, 2};
 
 #define RGB_SEEK(x,y) (set = rgb + 38 * (y) + (x))

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -124,7 +124,7 @@ void SmallVis::draw (QPainter & cr)
             {
                 int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
                 RGB_SEEK (x, h);
-                RGB_SET_INDEX (svis_scope_colors[h]);
+                RGB_SET_INDEX (18);
             }
             break;
         case SCOPE_LINE:
@@ -134,17 +134,16 @@ void SmallVis::draw (QPainter & cr)
                 int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
                 int h2 = scale[aud::clamp (m_data[2 * (x + 1)], 0, 16)];
 
-                if (h < h2) h2 --;
-                else if (h > h2) {int temp = h; h = h2 + 1; h2 = temp;}
+                if (h > h2) {int temp = h; h = h2; h2 = temp;}
 
                 RGB_SEEK (x, h);
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (18);
             }
 
             int h = scale[aud::clamp (m_data[74], 0, 16)];
             RGB_SEEK (37, h);
-            RGB_SET_INDEX (svis_scope_colors[h]);
+            RGB_SET_INDEX (18);
             break;
         }
         default: /* SCOPE_SOLID */
@@ -163,7 +162,7 @@ void SmallVis::draw (QPainter & cr)
 
                 RGB_SEEK (x, h);
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (18);
             }
             break;
         }

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -110,8 +110,8 @@ void SmallVis::draw (QPainter & cr)
         break;
     case VIS_SCOPE:
     {
-        static const int scale[17] = {0, 0, 0, 0, 0, 0, 1, 1, 2, 3, 3, 4,
-         4, 4, 4, 4, 4};
+        static const int scale[17] = {0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3,
+         3, 3, 3, 4, 4};
 
         if (! m_active)
             goto DRAW;

--- a/src/skins-qt/svis.cc
+++ b/src/skins-qt/svis.cc
@@ -64,8 +64,21 @@ void SmallVis::draw (QPainter & cr)
             h = aud::clamp (h, 0, 5);
             RGB_SEEK (x, 5 - h);
 
-            for (int y = 0; y < h; y ++)
-                RGB_SET_INDEX_Y (svis_analyzer_colors[h - 1 - y]);
+            switch (config.analyzer_mode)
+            {
+                case ANALYZER_NORMAL:
+                    for (int y = 0; y < h; y ++)
+                        RGB_SET_INDEX_Y (svis_analyzer_colors[h - 1 - y]);
+                break;
+                case ANALYZER_FIRE:
+                    for (int y = 0; y < h; y ++)
+                        RGB_SET_INDEX_Y (svis_analyzer_colors[4-y]);
+                break;
+                default: /* ANALYZER_VLINES */
+                    for (int y = 0; y < h; y ++)
+                        RGB_SET_INDEX_Y (svis_analyzer_colors[h-1]);
+                break;
+            }
         }
 
         break;

--- a/src/skins-qt/vis.cc
+++ b/src/skins-qt/vis.cc
@@ -35,6 +35,8 @@ static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
 static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
 static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 20, 19, 19, 18,
  18, 19, 19, 20, 20, 21, 21};
+int last_h = 0;
+int h2 = 0;
 
 #define RGB_SEEK(x,y) (set = rgb + 76 * (y) + (x))
 #define RGB_SET(c) (* set ++ = (c))
@@ -172,34 +174,36 @@ void SkinnedVis::draw (QPainter & cr)
         case SCOPE_DOT:
             for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
+                int h = aud::clamp ((int) m_data[x]-1, 0, 15);
                 RGB_SEEK (x, h);
                 RGB_SET_INDEX (vis_scope_colors[h]);
             }
             break;
         case SCOPE_LINE:
         {
-            for (int x = 0; x < 74; x ++)
+            for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
-                int h2 = aud::clamp ((int) m_data[x + 1], 0, 15);
+                int h = aud::clamp ((int) m_data[x]-1, 0, 15);
 
-                if (h < h2)
-                    h2 --;
-                else if (h > h2)
-                {
-                    int temp = h;
-                    h = h2 + 1;
-                    h2 = temp;
+                if (x == 0)
+                    last_h = h;
+
+                h2 = last_h;
+                last_h = h;
+
+                if (h2 < h) {
+                    int temp = h2;
+                    h2 = h;
+                    h = temp + 1;
                 }
 
                 RGB_SEEK (x, h);
 
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (vis_scope_colors[(h2 < h) ? h : h2]);
             }
 
-            int h = aud::clamp ((int) m_data[74], 0, 15);
+            int h = aud::clamp ((int) m_data[74]-1, 0, 15);
             RGB_SEEK (74, h);
             RGB_SET_INDEX (vis_scope_colors[h]);
             break;
@@ -207,7 +211,7 @@ void SkinnedVis::draw (QPainter & cr)
         default: /* SCOPE_SOLID */
             for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
+                int h = aud::clamp ((int) m_data[x]-1, 0, 15);
                 int h2;
 
                 if (h <= 7)

--- a/src/skins-qt/vis.cc
+++ b/src/skins-qt/vis.cc
@@ -132,7 +132,7 @@ void SkinnedVis::draw (QPainter & cr)
                 int h = m_peak[bars ? (x >> 2) : x];
                 h = aud::clamp (h, 0, 16);
 
-                if (h)
+                if (h > 1)
                 {
                     RGB_SEEK (x, 16 - h);
                     RGB_SET_INDEX (23);

--- a/src/skins-qt/vis.cc
+++ b/src/skins-qt/vis.cc
@@ -33,8 +33,8 @@
 
 static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
 static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
-static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 20, 19, 19, 18,
- 18, 19, 19, 20, 20, 21, 21};
+static const int vis_scope_colors[16] = {21, 21, 20, 20, 19, 19, 18, 18, 19,
+ 19, 20, 20, 21, 21, 22, 22};
 int last_h = 0;
 int h2 = 0;
 
@@ -200,7 +200,7 @@ void SkinnedVis::draw (QPainter & cr)
                 RGB_SEEK (x, h);
 
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[(h2 < h) ? h : h2]);
+                    RGB_SET_INDEX_Y (vis_scope_colors[(h2 > h) ? h : h2]);
             }
 
             int h = aud::clamp ((int) m_data[74]-1, 0, 15);

--- a/src/skins-qt/vis.cc
+++ b/src/skins-qt/vis.cc
@@ -221,7 +221,7 @@ void SkinnedVis::draw (QPainter & cr)
                 RGB_SEEK (x, h);
 
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (vis_scope_colors[(h <= 7) ? h : h2]);
             }
             break;
         }

--- a/src/skins-qt/vis.cc
+++ b/src/skins-qt/vis.cc
@@ -210,8 +210,8 @@ void SkinnedVis::draw (QPainter & cr)
                 int h = aud::clamp ((int) m_data[x], 0, 15);
                 int h2;
 
-                if (h < 8)
-                    h2 = 8;
+                if (h <= 7)
+                    h2 = 7;
                 else
                 {
                     h2 = h;

--- a/src/skins-qt/vis.cc
+++ b/src/skins-qt/vis.cc
@@ -107,7 +107,7 @@ void SkinnedVis::draw (QPainter & cr)
             if (bars && (x & 3) == 3)
                 continue;
 
-            int h = m_data[bars ? (x >> 2) : x];
+            int h = m_falloff[bars ? (x >> 2) : x];
             h = aud::clamp (h, 0, 16);
             RGB_SEEK (x, 16 - h);
 
@@ -132,9 +132,9 @@ void SkinnedVis::draw (QPainter & cr)
                 int h = m_peak[bars ? (x >> 2) : x];
                 h = aud::clamp (h, 0, 16);
 
-                if (h > 1)
+                if (h)
                 {
-                    RGB_SEEK (x, 16 - h);
+                    RGB_SEEK (x, 15 - h);
                     RGB_SET_INDEX (23);
                 }
             }
@@ -250,6 +250,7 @@ void SkinnedVis::clear ()
     m_voiceprint_advance = false;
 
     memset (m_data, 0, sizeof m_data);
+    memset (m_falloff, 0, sizeof m_falloff);
     memset (m_peak, 0, sizeof m_peak);
     memset (m_peak_speed, 0, sizeof m_peak_speed);
     memset (m_voiceprint_data, 0, sizeof m_voiceprint_data);
@@ -265,42 +266,33 @@ void SkinnedVis::render (const unsigned char * data)
 
         for (int i = 0; i < n; i ++)
         {
-            if (data[i] > m_data[i])
-            {
-                m_data[i] = data[i];
-                if (m_data[i] > m_peak[i])
-                {
-                    m_peak[i] = m_data[i];
-                    m_peak_speed[i] = 0.01;
+            m_data[i] = data[i];
 
-                }
-                else if (m_peak[i] > 0.0)
-                {
-                    m_peak[i] -= m_peak_speed[i];
-                    m_peak_speed[i] *= vis_pfalloff_speeds[config.peaks_falloff];
-                    if (m_peak[i] < m_data[i])
-                        m_peak[i] = m_data[i];
-                    if (m_peak[i] < 0.0)
-                        m_peak[i] = 0.0;
-                }
+            if (m_data[i] >= 15.0){
+                m_data[i] = 15.0;
             }
-            else
+
+            m_falloff[i] -= vis_afalloff_speeds[config.analyzer_falloff];
+            if (m_falloff[i] <= m_data[i]){
+                m_falloff[i] = m_data[i];
+            }
+            if (m_falloff[i] < 0.0)
+                m_falloff[i] = 0.0;
+
+            if (m_falloff[i] > m_peak[i])
             {
-                if (m_data[i] > 0.0)
-                {
-                    m_data[i] -= vis_afalloff_speeds[config.analyzer_falloff];
-                    if (m_data[i] < 0.0)
-                        m_data[i] = 0.0;
-                }
-                if (m_peak[i] > 0.0)
-                {
-                    m_peak[i] -= m_peak_speed[i];
-                    m_peak_speed[i] *= vis_pfalloff_speeds[config.peaks_falloff];
-                    if (m_peak[i] < m_data[i])
-                        m_peak[i] = m_data[i];
-                    if (m_peak[i] < 0.0)
-                        m_peak[i] = 0.0;
-                }
+                m_peak[i] = m_falloff[i];
+                m_peak_speed[i] = 0.01;
+
+            }
+
+            {
+                m_peak[i] -= m_peak_speed[i];
+                m_peak_speed[i] *= vis_pfalloff_speeds[config.peaks_falloff];
+                if (m_peak[i] <= m_falloff[i])
+                    m_peak[i] = m_falloff[i];
+                if (m_peak[i] < 0.0)
+                    m_peak[i] = 0.0;
             }
         }
     }

--- a/src/skins-qt/vis.cc
+++ b/src/skins-qt/vis.cc
@@ -33,8 +33,8 @@
 
 static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
 static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
-static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 10, 19, 19, 18,
- 19, 19, 20, 20, 21, 21, 22};
+static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 20, 19, 19, 18,
+ 18, 19, 19, 20, 20, 21, 21};
 
 #define RGB_SEEK(x,y) (set = rgb + 76 * (y) + (x))
 #define RGB_SET(c) (* set ++ = (c))

--- a/src/skins-qt/vis.h
+++ b/src/skins-qt/vis.h
@@ -69,7 +69,7 @@ private:
     uint32_t m_pattern_fill[76 * 2];
 
     bool m_active, m_voiceprint_advance;
-    float m_data[75], m_peak[75], m_peak_speed[75];
+    float m_data[75], m_falloff[75], m_peak[75], m_peak_speed[75];
     unsigned char m_voiceprint_data[76 * 16];
 };
 

--- a/src/skins-qt/vis.h
+++ b/src/skins-qt/vis.h
@@ -84,7 +84,7 @@ private:
     void draw (QPainter & cr);
 
     bool m_active;
-    int m_data[75];
+    float m_data[75], m_falloff[75], m_peak[75], m_peak_speed[75];
 };
 
 #endif

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -111,8 +111,8 @@ void SmallVis::draw (cairo_t * cr)
         break;
     case VIS_SCOPE:
     {
-        static const int scale[17] = {0, 0, 0, 0, 0, 0, 1, 1, 2, 3, 3, 4,
-         4, 4, 4, 4, 4};
+        static const int scale[17] = {0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3,
+         3, 3, 3, 4, 4};
 
         if (! m_active)
             goto DRAW;

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -235,8 +235,8 @@ void SmallVis::render (const unsigned char * data)
         {
             m_data[i] = data[i];
 
-            if (m_falloff[i] >= 5.0){
-                m_falloff[i] = 5.0;
+            if (m_data[i] >= 5.0){
+                m_data[i] = 5.0;
             }
 
             m_falloff[i] -= vis_afalloff_speeds[config.analyzer_falloff] / 4;

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -107,7 +107,7 @@ void SmallVis::draw (cairo_t * cr)
                 if (y == 2)
                     continue;
 
-                int h = (m_data[y / 3] * 8 + 19) / 38;
+                int h = (m_falloff[y / 3] * 8 + 19) / 38;
                 h = aud::clamp (h, 0, 8);
                 RGB_SEEK (0, y);
 
@@ -126,7 +126,7 @@ void SmallVis::draw (cairo_t * cr)
                 if (y == 2)
                     continue;
 
-                int h = m_data[y / 3];
+                int h = m_falloff[y / 3];
                 h = aud::clamp (h, 0, 38);
                 RGB_SEEK (0, y);
 
@@ -263,8 +263,16 @@ void SmallVis::render (const unsigned char * data)
     }
     else if (config.vis_type == VIS_VOICEPRINT)
     {
-        for (int i = 0; i < 2; i ++)
+        for (int i = 0; i < 2; i ++) {
             m_data[i] = data[i];
+
+            m_falloff[i] -= vis_afalloff_speeds[config.analyzer_falloff];
+            if (m_falloff[i] <= m_data[i]){
+                m_falloff[i] = m_data[i];
+            }
+            if (m_falloff[i] < 0.0)
+                m_falloff[i] = 0.0;
+        }
     }
     else
     {

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -33,7 +33,6 @@
 #include "vis.h"
 
 static const int svis_analyzer_colors[] = {14, 11, 8, 5, 2};
-static const int svis_scope_colors[] = {20, 19, 18, 19, 20};
 static const int svis_vu_normal_colors[] = {16, 14, 12, 10, 8, 6, 4, 2};
 
 #define RGB_SEEK(x,y) (set = rgb + 38 * (y) + (x))
@@ -125,7 +124,7 @@ void SmallVis::draw (cairo_t * cr)
             {
                 int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
                 RGB_SEEK (x, h);
-                RGB_SET_INDEX (svis_scope_colors[h]);
+                RGB_SET_INDEX (18);
             }
             break;
         case SCOPE_LINE:
@@ -140,12 +139,12 @@ void SmallVis::draw (cairo_t * cr)
 
                 RGB_SEEK (x, h);
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (18);
             }
 
             int h = scale[aud::clamp (m_data[74], 0, 16)];
             RGB_SEEK (37, h);
-            RGB_SET_INDEX (svis_scope_colors[h]);
+            RGB_SET_INDEX (18);
             break;
         }
         default: /* SCOPE_SOLID */
@@ -164,7 +163,7 @@ void SmallVis::draw (cairo_t * cr)
 
                 RGB_SEEK (x, h);
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (svis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (18);
             }
             break;
         }

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -56,7 +56,7 @@ void SmallVis::draw (cairo_t * cr)
     {
         bool bars = (config.analyzer_type == ANALYZER_BARS);
 
-        for (int x = 0; x < 38; x ++)
+        for (int x = 0; x < 37; x ++)
         {
             if (bars && (x % 3) == 2)
                 continue;

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -32,6 +32,8 @@
 #include "skin.h"
 #include "vis.h"
 
+static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
+static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
 static const int svis_analyzer_colors[] = {17, 14, 11, 8, 4};
 static const int svis_vu_normal_colors[] = {16, 14, 12, 10, 8, 6, 4, 2};
 
@@ -61,12 +63,37 @@ void SmallVis::draw (cairo_t * cr)
             if (bars && (x % 3) == 2)
                 continue;
 
-            int h = m_data[bars ? (x / 3) : x];
+            int h = m_falloff[bars ? (x / 3) : x];
             h = aud::clamp (h, 0, 5);
             RGB_SEEK (x, 5 - h);
 
-            for (int y = 0; y < h; y ++)
-                RGB_SET_INDEX_Y (svis_analyzer_colors[h - 1 - y]);
+            switch (config.analyzer_mode)
+            {
+                case ANALYZER_NORMAL:
+                    for (int y = 0; y < h; y ++)
+                        RGB_SET_INDEX_Y (svis_analyzer_colors[h - 1 - y]);
+                break;
+                case ANALYZER_FIRE:
+                    for (int y = 0; y < h; y ++)
+                        RGB_SET_INDEX_Y (svis_analyzer_colors[4-y]);
+                break;
+                default: /* ANALYZER_VLINES */
+                    for (int y = 0; y < h; y ++)
+                        RGB_SET_INDEX_Y (svis_analyzer_colors[h-1]);
+                break;
+            }
+
+            if (config.analyzer_peaks)
+            {
+                int h = m_peak[bars ? (x / 3) : x];
+                h = aud::clamp (h, 0, 5);
+
+                if (h >= 5)
+                    continue;
+                RGB_SEEK (x, 4 - h);
+                RGB_SET_INDEX (23);
+
+            }
         }
 
         break;
@@ -122,7 +149,7 @@ void SmallVis::draw (cairo_t * cr)
         case SCOPE_DOT:
             for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
+                int h = scale[aud::clamp ((int) m_data[2 * x], 0, 16)];
                 RGB_SEEK (x, h);
                 RGB_SET_INDEX (18);
             }
@@ -131,18 +158,17 @@ void SmallVis::draw (cairo_t * cr)
         {
             for (int x = 0; x < 37; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
-                int h2 = scale[aud::clamp (m_data[2 * (x + 1)], 0, 16)];
+                int h = scale[aud::clamp ((int) m_data[2 * x], 0, 16)];
+                int h2 = scale[aud::clamp ((int) m_data[2 * (x + 1)], 0, 16)];
 
-                if (h < h2) h2 --;
-                else if (h > h2) {int temp = h; h = h2 + 1; h2 = temp;}
+                if (h > h2) {int temp = h; h = h2; h2 = temp;}
 
                 RGB_SEEK (x, h);
                 for (int y = h; y <= h2; y ++)
                     RGB_SET_INDEX_Y (18);
             }
 
-            int h = scale[aud::clamp (m_data[74], 0, 16)];
+            int h = scale[aud::clamp ((int) m_data[74], 0, 16)];
             RGB_SEEK (37, h);
             RGB_SET_INDEX (18);
             break;
@@ -150,7 +176,7 @@ void SmallVis::draw (cairo_t * cr)
         default: /* SCOPE_SOLID */
             for (int x = 0; x < 38; x ++)
             {
-                int h = scale[aud::clamp (m_data[2 * x], 0, 16)];
+                int h = scale[aud::clamp ((int) m_data[2 * x], 0, 16)];
                 int h2;
 
                 if (h < 2)
@@ -191,12 +217,51 @@ void SmallVis::clear ()
 {
     m_active = false;
     memset (m_data, 0, sizeof m_data);
+    memset (m_falloff, 0, sizeof m_falloff);
+    memset (m_peak, 0, sizeof m_peak);
+    memset (m_peak_speed, 0, sizeof m_peak_speed);
     queue_draw ();
 }
 
 void SmallVis::render (const unsigned char * data)
 {
-    if (config.vis_type == VIS_VOICEPRINT)
+    if (config.vis_type == VIS_ANALYZER)
+    {
+        const int n = (config.analyzer_type == ANALYZER_BARS) ? 19 : 75;
+
+        for (int i = 0; i < n; i ++)
+        {
+            m_data[i] = data[i];
+
+            if (m_falloff[i] >= 5.0){
+                m_falloff[i] = 5.0;
+            }
+
+            m_falloff[i] -= vis_afalloff_speeds[config.analyzer_falloff] / 4;
+            if (m_falloff[i] <= m_data[i]){
+                m_falloff[i] = m_data[i];
+            }
+            if (m_falloff[i] < 0.0)
+                m_falloff[i] = 0.0;
+
+            if (m_falloff[i] > m_peak[i])
+            {
+                m_peak[i] = m_falloff[i];
+                m_peak_speed[i] = 0.01;
+
+            }
+
+            {
+                m_peak[i] -= m_peak_speed[i] / 4;
+                m_peak_speed[i] *= vis_pfalloff_speeds[config.peaks_falloff];
+                if (m_peak[i] <= m_falloff[i])
+                    m_peak[i] = m_falloff[i];
+                if (m_peak[i] < 0.0)
+                    m_peak[i] = 0.0;
+            }
+        }
+    }
+    else if (config.vis_type == VIS_VOICEPRINT)
     {
         for (int i = 0; i < 2; i ++)
             m_data[i] = data[i];

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -26,6 +26,7 @@
 
 #include <string.h>
 #include <libaudcore/objects.h>
+#include <libaudcore/drct.h>
 
 #include "skins_cfg.h"
 #include "surface.h"
@@ -88,11 +89,12 @@ void SmallVis::draw (cairo_t * cr)
                 int h = m_peak[bars ? (x / 3) : x];
                 h = aud::clamp (h, 0, 5);
 
-                if (h >= 5)
-                    continue;
-                RGB_SEEK (x, 4 - h);
-                RGB_SET_INDEX (23);
-
+                if (aud_drct_get_playing ()) {
+                    if (h >= 5)
+                        continue;
+                    RGB_SEEK (x, 4 - h);
+                    RGB_SET_INDEX (23);
+                }
             }
         }
 

--- a/src/skins/svis.cc
+++ b/src/skins/svis.cc
@@ -32,7 +32,7 @@
 #include "skin.h"
 #include "vis.h"
 
-static const int svis_analyzer_colors[] = {14, 11, 8, 5, 2};
+static const int svis_analyzer_colors[] = {17, 14, 11, 8, 4};
 static const int svis_vu_normal_colors[] = {16, 14, 12, 10, 8, 6, 4, 2};
 
 #define RGB_SEEK(x,y) (set = rgb + 38 * (y) + (x))

--- a/src/skins/vis.cc
+++ b/src/skins/vis.cc
@@ -33,8 +33,8 @@
 
 static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
 static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
-static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 20, 19, 19, 18,
- 18, 19, 19, 20, 20, 21, 21};
+static const int vis_scope_colors[16] = {21, 21, 20, 20, 19, 19, 18, 18, 19,
+ 19, 20, 20, 21, 21, 22, 22};
 int last_h = 0;
 int h2 = 0;
 
@@ -200,7 +200,7 @@ void SkinnedVis::draw (cairo_t * cr)
                 RGB_SEEK (x, h);
 
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[(h2 < h) ? h : h2]);
+                    RGB_SET_INDEX_Y (vis_scope_colors[(h2 > h) ? h : h2]);
             }
 
             int h = aud::clamp ((int) m_data[74]-1, 0, 15);

--- a/src/skins/vis.cc
+++ b/src/skins/vis.cc
@@ -210,8 +210,8 @@ void SkinnedVis::draw (cairo_t * cr)
                 int h = aud::clamp ((int) m_data[x], 0, 15);
                 int h2;
 
-                if (h < 8)
-                    h2 = 8;
+                if (h <= 7)
+                    h2 = 7;
                 else
                 {
                     h2 = h;

--- a/src/skins/vis.cc
+++ b/src/skins/vis.cc
@@ -221,7 +221,7 @@ void SkinnedVis::draw (cairo_t * cr)
                 RGB_SEEK (x, h);
 
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (vis_scope_colors[(h <= 7) ? h : h2]);
             }
             break;
         }

--- a/src/skins/vis.cc
+++ b/src/skins/vis.cc
@@ -132,7 +132,7 @@ void SkinnedVis::draw (cairo_t * cr)
                 int h = m_peak[bars ? (x >> 2) : x];
                 h = aud::clamp (h, 0, 16);
 
-                if (h)
+                if (h > 1)
                 {
                     RGB_SEEK (x, 16 - h);
                     RGB_SET_INDEX (23);

--- a/src/skins/vis.cc
+++ b/src/skins/vis.cc
@@ -35,6 +35,8 @@ static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
 static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
 static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 20, 19, 19, 18,
  18, 19, 19, 20, 20, 21, 21};
+int last_h = 0;
+int h2 = 0;
 
 #define RGB_SEEK(x,y) (set = rgb + 76 * (y) + (x))
 #define RGB_SET(c) (* set ++ = (c))
@@ -172,34 +174,36 @@ void SkinnedVis::draw (cairo_t * cr)
         case SCOPE_DOT:
             for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
+                int h = aud::clamp ((int) m_data[x]-1, 0, 15);
                 RGB_SEEK (x, h);
                 RGB_SET_INDEX (vis_scope_colors[h]);
             }
             break;
         case SCOPE_LINE:
         {
-            for (int x = 0; x < 74; x ++)
+            for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
-                int h2 = aud::clamp ((int) m_data[x + 1], 0, 15);
+                int h = aud::clamp ((int) m_data[x]-1, 0, 15);
 
-                if (h < h2)
-                    h2 --;
-                else if (h > h2)
-                {
-                    int temp = h;
-                    h = h2 + 1;
-                    h2 = temp;
+                if (x == 0)
+                    last_h = h;
+
+                h2 = last_h;
+                last_h = h;
+
+                if (h2 < h) {
+                    int temp = h2;
+                    h2 = h;
+                    h = temp + 1;
                 }
 
                 RGB_SEEK (x, h);
 
                 for (int y = h; y <= h2; y ++)
-                    RGB_SET_INDEX_Y (vis_scope_colors[y]);
+                    RGB_SET_INDEX_Y (vis_scope_colors[(h2 < h) ? h : h2]);
             }
 
-            int h = aud::clamp ((int) m_data[74], 0, 15);
+            int h = aud::clamp ((int) m_data[74]-1, 0, 15);
             RGB_SEEK (74, h);
             RGB_SET_INDEX (vis_scope_colors[h]);
             break;
@@ -207,7 +211,7 @@ void SkinnedVis::draw (cairo_t * cr)
         default: /* SCOPE_SOLID */
             for (int x = 0; x < 75; x ++)
             {
-                int h = aud::clamp ((int) m_data[x], 0, 15);
+                int h = aud::clamp ((int) m_data[x]-1, 0, 15);
                 int h2;
 
                 if (h <= 7)

--- a/src/skins/vis.cc
+++ b/src/skins/vis.cc
@@ -33,8 +33,8 @@
 
 static const float vis_afalloff_speeds[] = {0.34, 0.5, 1.0, 1.3, 1.6};
 static const float vis_pfalloff_speeds[] = {1.2, 1.3, 1.4, 1.5, 1.6};
-static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 10, 19, 19, 18,
- 19, 19, 20, 20, 21, 21, 22};
+static const int vis_scope_colors[16] = {22, 22, 21, 21, 20, 20, 19, 19, 18,
+ 18, 19, 19, 20, 20, 21, 21};
 
 #define RGB_SEEK(x,y) (set = rgb + 76 * (y) + (x))
 #define RGB_SET(c) (* set ++ = (c))

--- a/src/skins/vis.h
+++ b/src/skins/vis.h
@@ -69,7 +69,7 @@ private:
     uint32_t m_pattern_fill[76 * 2];
 
     bool m_active, m_voiceprint_advance;
-    float m_data[75], m_peak[75], m_peak_speed[75];
+    float m_data[75], m_falloff[75], m_peak[75], m_peak_speed[75];
     unsigned char m_voiceprint_data[76 * 16];
 };
 

--- a/src/skins/vis.h
+++ b/src/skins/vis.h
@@ -84,7 +84,7 @@ private:
     void draw (cairo_t * cr);
 
     bool m_active;
-    int m_data[75];
+    float m_data[75], m_falloff[75], m_peak[75], m_peak_speed[75];
 };
 
 #endif


### PR DESCRIPTION
This PR aims to rework the visualizer seen in the Winamp Classic Interface.

___

## Motivation

Reimplementations of the Winamp Classic UI, like Webamp, have studied and reimplemented all sorts of small details that makes classic skins look and feel as though you were actually using Winamp, the downside is that Webamp only exists in the browser and is not a fully fledged media player.

Though people still have a desire to re-experience those skins again, and more often than not, they install Audacious, which does a pretty decent job of emulating classic skins, but it could be better in some areas. This PR touches on the visualizer aspect of it.

<details>

<summary>Audacious vs. my patch series comparison</summary>

<img width="550" height="286" alt="comparison" src="https://github.com/user-attachments/assets/3edbca23-a142-49c5-a451-7840131af347" />

The top blocks shows Audacious' skins-qt (on the left) in its current state, next to skins-qt with my changes.
The windowshaded shows the lines mode in the same fashion, skins-qt with my patches applied at the top, current git below it, the same goes for the solid mode.

Spectrum analyzer comparison, the top window is more stable and smooth, whereas the bottom is more jittery and unstable:
![ezgif-3836ffc9fd4427](https://github.com/user-attachments/assets/1ba1990f-9fef-47a6-83e6-e830e27c3b8e)

In the windowshaded mode, the analyzer used to not have any sort of falloff applied and was instead very reactive, it was also missing peaks:
![ezgif-3b380af9f69f0b](https://github.com/user-attachments/assets/8d7b1061-b78f-46ff-8062-b34e508387e7)

The same applies to the VU Meter (just that it isn't missing the peaks, they weren't there to begin with in Winamp):
![ezgif-3c2565f45b40db](https://github.com/user-attachments/assets/27afc424-3c3f-4ce5-be5b-3204cb982da4)

</details>

## Codebase changes

The changes were only done in ``vis.cc``, ``svis.cc`` and ``vis.h`` (in both ``skins-qt`` and ``skins`` respectively), the focus was on improving the rendering styles for the Oscilloscope and Analyzer modes, with additions and refactoring done where necessary.
This also included a bugfix, where for the longest time, the oscilloscope had both the wrong color order, as well as having one of the colors from the analyzer incorrectly assigned to it.

The line mode for the scope was improved based on observations of Winamp and Webamp, as well as the solid mode, the dots mode remained unchanged.
This improvement was also applied to the mini visualizer, with the weird line drawing that's done and it only using one color for the overall scope, the scale for the audio data was also adjusted, as it visually appeared "too loud".

___

This is my second attempt at wanting to improve Audacious' Winamp skins support which is more focused and (hopefully) more organized, I will admit though that I did tend to forget to update ``skins`` as I primarily was using and testing with the Qt version, but from my own testing, they should at least line up with what I was seeing on my end.

I hope that this PR doesn't cause too much trouble.