### PR TITLE
Add toggle buttons for 'No Playlist Advance' using ① (U+2460)

### DIFF
--- a/src/gtkui/ui_gtk.cc
+++ b/src/gtkui/ui_gtk.cc
@@ -136,7 +136,7 @@ static GtkWidget * window, * vbox_outer, * menu_box, * menu, * toolbar, * vbox,
  * infoarea, * statusbar;
 static GtkToolItem * menu_button, * search_button, * button_open, * button_add,
  * button_prev, * button_play, * button_stop, * button_next, * button_record,
- * button_repeat, * button_shuffle;
+ * button_repeat, * button_shuffle, * button_no_playlist_advance;
 static GtkWidget * slider, * label_time;
 static GtkWidget * menu_main, * menu_rclick, * menu_tab;
 
@@ -473,6 +473,9 @@ static void set_menu_button_icon (GtkToolButton * button)
 
 static void set_button_icon (GtkToolButton * button, const char * icon)
 {
+    if (! icon)
+        return;
+
     if (aud_get_bool ("gtkui", "symbolic_icons"))
         gtk_tool_button_set_icon_name (button, str_concat ({icon, "-symbolic"}));
     else
@@ -698,6 +701,8 @@ static void update_toggles (void * = nullptr, void * = nullptr)
      aud_get_bool ("repeat"));
     gtk_toggle_tool_button_set_active ((GtkToggleToolButton *) button_shuffle,
      aud_get_bool ("shuffle"));
+    gtk_toggle_tool_button_set_active ((GtkToggleToolButton *) button_no_playlist_advance,
+     aud_get_bool ("no_playlist_advance"));
 }
 
 static void toggle_repeat (GtkToggleToolButton * button)
@@ -708,6 +713,11 @@ static void toggle_repeat (GtkToggleToolButton * button)
 static void toggle_shuffle (GtkToggleToolButton * button)
 {
     aud_set_bool ("shuffle", gtk_toggle_tool_button_get_active (button));
+}
+
+static void toggle_no_playlist_advance (GtkToggleToolButton * button)
+{
+    aud_set_bool ("no_playlist_advance", gtk_toggle_tool_button_get_active (button));
 }
 
 static void toggle_record (GtkToggleToolButton * button)
@@ -754,8 +764,9 @@ static void ui_hooks_associate ()
     hook_associate ("playlist position", pl_notebook_set_position, nullptr);
     hook_associate ("enable record", update_toggles, nullptr);
     hook_associate ("set record", update_toggles, nullptr);
-    hook_associate ("set shuffle", update_toggles, nullptr);
     hook_associate ("set repeat", update_toggles, nullptr);
+    hook_associate ("set shuffle", update_toggles, nullptr);
+    hook_associate ("set no_playlist_advance", update_toggles, nullptr);
     hook_associate ("set step_size", (HookFunction) update_step_size, nullptr);
     hook_associate ("set volume_delta", (HookFunction) update_volume_delta, nullptr);
     hook_associate ("config save", (HookFunction) config_save, nullptr);
@@ -775,8 +786,9 @@ static void ui_hooks_disassociate ()
     hook_dissociate ("playlist position", pl_notebook_set_position);
     hook_dissociate ("enable record", update_toggles);
     hook_dissociate ("set record", update_toggles);
-    hook_dissociate ("set shuffle", update_toggles);
     hook_dissociate ("set repeat", update_toggles);
+    hook_dissociate ("set shuffle", update_toggles);
+    hook_dissociate ("set no_playlist_advance", update_toggles);
     hook_dissociate ("set step_size", (HookFunction) update_step_size);
     hook_dissociate ("set volume_delta", (HookFunction) update_volume_delta);
     hook_dissociate ("config save", (HookFunction) config_save);
@@ -922,6 +934,11 @@ bool GtkUI::init ()
     button_shuffle = toggle_button_new ("media-playlist-shuffle", _("Shuffle"),
      toggle_shuffle, aud_get_bool ("shuffle"));
     gtk_toolbar_insert ((GtkToolbar *) toolbar, button_shuffle, -1);
+
+    button_no_playlist_advance = toggle_button_new (nullptr, _("No Playlist Advance"),
+     toggle_no_playlist_advance, aud_get_bool ("no_playlist_advance"));
+    gtk_tool_button_set_label ((GtkToolButton *) button_no_playlist_advance, "①");
+    gtk_toolbar_insert ((GtkToolbar *) toolbar, button_no_playlist_advance, -1);
 
     /* volume button */
     GtkToolItem * boxitem2 = gtk_tool_item_new ();

--- a/src/qtui/main_window.cc
+++ b/src/qtui/main_window.cc
@@ -176,6 +176,10 @@ MainWindow::MainWindow()
         ToolBarAction(
             "media-playlist-shuffle", N_("Shuffle"), N_("Shuffle"),
             [](bool on) { aud_set_bool("shuffle", on); }, &m_shuffle_action),
+        ToolBarAction(
+            nullptr, "①", N_("No Playlist Advance"),
+            [](bool on) { aud_set_bool("no_playlist_advance", on); },
+            &m_no_playlist_advance_action),
         ToolBarCustom(audqt::volume_button_new(this))};
 
     auto toolbar = new ToolBar(this, items);
@@ -328,6 +332,8 @@ void MainWindow::update_toggles()
 
     m_repeat_action->setChecked(aud_get_bool("repeat"));
     m_shuffle_action->setChecked(aud_get_bool("shuffle"));
+    m_no_playlist_advance_action->setChecked(
+        aud_get_bool("no_playlist_advance"));
 }
 
 void MainWindow::update_visibility()

--- a/src/qtui/main_window.h
+++ b/src/qtui/main_window.h
@@ -56,7 +56,7 @@ private:
     QAction *m_menu_action, *m_search_action;
     QAction *m_play_pause_action, *m_stop_action, *m_stop_after_action;
     QAction * m_record_action;
-    QAction *m_repeat_action, *m_shuffle_action;
+    QAction *m_repeat_action, *m_shuffle_action, *m_no_playlist_advance_action;
 
     QueuedFunc m_buffering_timer;
     Playlist m_last_playing;
@@ -116,13 +116,14 @@ private:
         hook9{"set record", this, &MainWindow::update_toggles},
         hook10{"set repeat", this, &MainWindow::update_toggles},
         hook11{"set shuffle", this, &MainWindow::update_toggles},
-        hook12{"qtui toggle menubar", this, &MainWindow::update_visibility},
-        hook13{"qtui toggle infoarea", this, &MainWindow::update_visibility},
-        hook14{"qtui toggle statusbar", this, &MainWindow::update_visibility},
-        hook15{"qtui show search tool", this, &MainWindow::show_search_tool},
-        hook16{"qtui show playback history", this,
+        hook12{"set no_playlist_advance", this, &MainWindow::update_toggles},
+        hook13{"qtui toggle menubar", this, &MainWindow::update_visibility},
+        hook14{"qtui toggle infoarea", this, &MainWindow::update_visibility},
+        hook15{"qtui toggle statusbar", this, &MainWindow::update_visibility},
+        hook16{"qtui show search tool", this, &MainWindow::show_search_tool},
+        hook17{"qtui show playback history", this,
                &MainWindow::show_playback_history},
-        hook17{"qtui show playlist manager", this,
+        hook18{"qtui show playlist manager", this,
                &MainWindow::show_playlist_manager};
 };
 

--- a/src/qtui/tool_bar.cc
+++ b/src/qtui/tool_bar.cc
@@ -45,9 +45,10 @@ ToolBar::ToolBar(QWidget * parent, ArrayRef<ToolBarItem> items)
             a = addWidget(item.widget);
         else if (item.sep)
             a = addSeparator();
-        else if (item.icon_name)
+        else if (item.icon_name || item.name)
         {
-            a = new QAction(QIcon::fromTheme(item.icon_name),
+            a = new QAction(item.icon_name ? QIcon::fromTheme(item.icon_name)
+                                           : QIcon(),
                             audqt::translate_str(item.name), this);
 
             if (item.tooltip_text)


### PR DESCRIPTION
Alternative approach to:
- #181

Unicode ① (U+2460) seems like a suitable graphic for the buttons and avoids having to add new icons, which would not fit in with the system icon theme anyway.

I also changed the button order (repeat, shuffle, no playlist advance) and fixed up the gtkui implementation, which wasn't updating the toggle button properly at startup or when toggled via menu/hotkey.