### PR TITLE
alsa: Add configurable delay after sample rate change

### DIFF
--- a/src/alsa/alsa.cc
+++ b/src/alsa/alsa.cc
@@ -87,6 +87,8 @@ static pollfd * poll_handles;
 static bool pump_quit;
 static pthread_t pump_thread;
 
+static int alsa_rate_change_silence_ms;
+
 static snd_mixer_t * alsa_mixer;
 static snd_mixer_elem_t * alsa_mixer_element;
 
@@ -237,10 +239,45 @@ static void pump_stop ()
     pump_quit = false;
 }
 
+static void write_silence_locked (int ms)
+{
+    int frames = aud::rescale<int64_t> (ms, 1000, alsa_rate);
+    int period_frames = aud::rescale<int64_t> (alsa_period, 1000, alsa_rate);
+
+    if (frames <= 0 || period_frames <= 0)
+        return;
+
+    int buf_bytes = snd_pcm_frames_to_bytes (alsa_handle, period_frames);
+    char * silence = new char[buf_bytes]();
+
+    int remaining = frames;
+    while (remaining > 0)
+    {
+        int written = snd_pcm_writei (alsa_handle, silence,
+         aud::min (remaining, period_frames));
+        if (written < 0)
+        {
+            written = snd_pcm_recover (alsa_handle, written, 0);
+            if (written < 0)
+                break;
+            continue;
+        }
+        remaining -= written;
+    }
+
+    delete[] silence;
+}
+
 static void start_playback ()
 {
     AUDDBG ("Starting playback.\n");
     CHECK (snd_pcm_prepare, alsa_handle);
+
+    if (alsa_rate_change_silence_ms > 0)
+    {
+        write_silence_locked (alsa_rate_change_silence_ms);
+        alsa_rate_change_silence_ms = 0;
+    }
 
 FAILED:
     alsa_prebuffer = false;
@@ -317,6 +354,8 @@ bool ALSAPlugin::open_audio (int aud_format, int rate, int channels, String & er
 
     pthread_mutex_lock (& alsa_mutex);
 
+    int prev_rate = alsa_rate;
+
     assert (! alsa_handle);
 
     String pcm = aud_get_str ("alsa", "pcm");
@@ -376,6 +415,14 @@ bool ALSAPlugin::open_audio (int aud_format, int rate, int channels, String & er
         goto FAILED;
 
     pump_start ();
+
+    alsa_rate_change_silence_ms = 0;
+    if (prev_rate != rate)
+    {
+        int ms = aud_get_int ("alsa", "sample-rate-delay");
+        if (ms > 0)
+            alsa_rate_change_silence_ms = ms;
+    }
 
     pthread_mutex_unlock (& alsa_mutex);
     return true;

--- a/src/alsa/config.cc
+++ b/src/alsa/config.cc
@@ -241,6 +241,7 @@ static void guess_element ()
 const char * const ALSAPlugin::defaults[] = {
     "pcm", "default",
     "mixer", "default",
+    "sample-rate-delay", "0",
     nullptr
 };
 
@@ -301,7 +302,10 @@ const PreferencesWidget ALSAPlugin::widgets[] = {
         {nullptr, mixer_combo_fill}),
     WidgetCombo (N_("Mixer element:"),
         WidgetString ("alsa", "mixer-element", element_changed, "alsa mixer changed"),
-        {nullptr, element_combo_fill})
+        {nullptr, element_combo_fill}),
+    WidgetSpin (N_("Sample rate change delay:"),
+        WidgetInt ("alsa", "sample-rate-delay"),
+        {0, 10000, 10, N_("ms")})
 };
 
 static void alsa_prefs_init ()


### PR DESCRIPTION
## Summary

- Adds a `write_silence_locked()` helper that writes zero-filled frames to the PCM device via `snd_pcm_writei` for a configurable duration
- Hooks into `start_playback()` immediately after `snd_pcm_prepare()` succeeds, so silence is written while the mutex is held and the pump thread is blocked — the only point where a direct write survives to hardware
- Detects rate changes (including cold start, where the previous rate is 0) in `open_audio()` and arms the silence duration if the setting is non-zero
- Exposes the setting as a spin button in the ALSA plugin preferences (0–10000 ms, step 10, default 0 = disabled)

## Motivation

Some hardware DACs need a short settling period when the PCM sample rate changes. Without a delay, the first few milliseconds of audio after a rate transition are lost or corrupted. This is also observable on cold start when audacious first opens the audio device.

## Test plan

- [ ] Set delay to 0 — verify no audible change in behaviour for same-rate tracks
- [ ] Set delay to 150 ms — verify silence is heard between tracks with different sample rates
- [ ] Set delay to 150 ms — verify silence is heard at the start of the first track after launch
- [ ] Verify the spin button appears in Preferences → Output → ALSA
- [ ] Verify the setting persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)