### PR TITLE
allow dropping skin files on main window of skins interface

### DIFF
--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -55,12 +55,11 @@
 #include "number.h"
 #include "playlist-widget.h"
 #include "playstatus.h"
+#include "skin.h"
 #include "textbox.h"
 #include "window.h"
 #include "vis.h"
 #include "view.h"
-#include "skin.h"
-#include "skinselector.h"
 
 #include <QDragEnterEvent>
 #include <QMimeData>
@@ -579,19 +578,19 @@ void MainWindow::dropEvent (QDropEvent * event)
     if (! mimedata->hasUrls ())
         return;
 
-    Index<PlaylistAddItem> playlist_files;
+    Index<PlaylistAddItem> files;
     bool installed_skin = false;
 
     for (const auto & url : mimedata->urls ())
     {
         if (url.isLocalFile ())
         {
-            String path = String ((const char *) url.toLocalFile ().toUtf8 ());
+            QByteArray local_file = url.toLocalFile ().toUtf8 ();
+            const char * path = local_file.constData ();
 
-            if (str_has_suffix_nocase (path, ".wsz") || str_has_suffix_nocase (path, ".zip"))
+            if (str_has_suffix_nocase (path, ".wsz") ||
+                str_has_suffix_nocase (path, ".zip"))
             {
-                AUDDBG ("Attempting to load dropped skin: %s\n", (const char *) path);
-
                 if (! skin_load (path))
                     continue;
 
@@ -602,48 +601,17 @@ void MainWindow::dropEvent (QDropEvent * event)
             }
         }
 
-        playlist_files.append (String (url.toEncoded ()));
+        files.append (String (url.toEncoded ()));
     }
 
-    if (installed_skin)
+    if (files.len ())
     {
-        skinlist_update ();
-        mainwin_show_status_message (_("Skin installed."));
-    }
-
-    if (playlist_files.len ())
-    {
-        aud_drct_pl_open_list (std::move (playlist_files));
+        aud_drct_pl_open_list (std::move (files));
         event->acceptProposedAction ();
     }
     else if (installed_skin)
-    {
         event->acceptProposedAction ();
-    }
 }
-
-#if 0
-void mainwin_drag_data_received (GtkWidget * widget, GdkDragContext * context,
- int x, int y, GtkSelectionData * selection_data, unsigned info, unsigned time, void *)
-{
-    g_return_if_fail (selection_data != nullptr);
-
-    const char * data = (const char *) gtk_selection_data_get_data (selection_data);
-    g_return_if_fail (data);
-
-    if (str_has_prefix_nocase (data, "file:///"))
-    {
-        if (str_has_suffix_nocase (data, ".wsz\r\n") || str_has_suffix_nocase
-         (data, ".zip\r\n"))
-        {
-            on_skin_view_drag_data_received (0, context, x, y, selection_data, info, time, 0);
-            return;
-        }
-    }
-
-    audgui_urilist_open (data);
-}
-#endif
 
 static int time_now ()
 {

--- a/src/skins-qt/main.cc
+++ b/src/skins-qt/main.cc
@@ -59,6 +59,8 @@
 #include "window.h"
 #include "vis.h"
 #include "view.h"
+#include "skin.h"
+#include "skinselector.h"
 
 #include <QDragEnterEvent>
 #include <QMimeData>
@@ -577,16 +579,47 @@ void MainWindow::dropEvent (QDropEvent * event)
     if (! mimedata->hasUrls ())
         return;
 
-    Index<PlaylistAddItem> files;
+    Index<PlaylistAddItem> playlist_files;
+    bool installed_skin = false;
 
     for (const auto & url : mimedata->urls ())
-        files.append (String (url.toEncoded ()));
+    {
+        if (url.isLocalFile ())
+        {
+            String path = String ((const char *) url.toLocalFile ().toUtf8 ());
 
-    if (! files.len ())
-        return;
+            if (str_has_suffix_nocase (path, ".wsz") || str_has_suffix_nocase (path, ".zip"))
+            {
+                AUDDBG ("Attempting to load dropped skin: %s\n", (const char *) path);
 
-    aud_drct_pl_open_list (std::move (files));
-    event->acceptProposedAction ();
+                if (! skin_load (path))
+                    continue;
+
+                view_apply_skin ();
+                skin_install_skin (path);
+                installed_skin = true;
+                continue;
+            }
+        }
+
+        playlist_files.append (String (url.toEncoded ()));
+    }
+
+    if (installed_skin)
+    {
+        skinlist_update ();
+        mainwin_show_status_message (_("Skin installed."));
+    }
+
+    if (playlist_files.len ())
+    {
+        aud_drct_pl_open_list (std::move (playlist_files));
+        event->acceptProposedAction ();
+    }
+    else if (installed_skin)
+    {
+        event->acceptProposedAction ();
+    }
 }
 
 #if 0

--- a/src/skins-qt/skins_cfg.cc
+++ b/src/skins-qt/skins_cfg.cc
@@ -309,31 +309,3 @@ static const PreferencesWidget skins_widgets[] = {
 };
 
 const PluginPreferences skins_prefs = {{skins_widgets}};
-
-#if 0
-void on_skin_view_drag_data_received (GtkWidget * widget, GdkDragContext * context,
- int x, int y, GtkSelectionData * selection_data, unsigned info, unsigned time, void *)
-{
-    const char * data = (const char *) gtk_selection_data_get_data (selection_data);
-    g_return_if_fail (data);
-
-    const char * end = strchr (data, '\r');
-    if (! end)
-        end = strchr (data, '\n');
-    if (! end)
-        end = data + strlen (data);
-
-    StringBuf path = uri_to_filename (str_copy (data, end - data));
-    if (path && file_is_archive (path))
-    {
-        if (! skin_load (path))
-            return;
-
-        view_apply_skin ();
-        skin_install_skin (path);
-
-        if (skin_view)
-            skin_view_update ((GtkTreeView *) skin_view);
-    }
-}
-#endif

--- a/src/skins-qt/skins_cfg.h
+++ b/src/skins-qt/skins_cfg.h
@@ -47,12 +47,6 @@ extern skins_cfg_t config;
 void skins_cfg_load ();
 void skins_cfg_save ();
 
-#if 0
-void on_skin_view_drag_data_received (GtkWidget * widget,
- GdkDragContext * context, int x, int y, GtkSelectionData * selection_data,
- unsigned info, unsigned time, void * data);
-#endif
-
 extern const PluginPreferences skins_prefs;
 
 #endif


### PR DESCRIPTION
As suggested in my previos PR, this one allows dropping skin files onto the main window of the skins interface.
I wasn't sure what the original winamp behaviour was, so I went with the following:
- Skins have to appear on the toplevel list of dropped files as .zip or .wsz
- Multiple skins can be imported at once, and the last one will be activated
- Skins can be mixed with media files, in which case the skins are pulled from the list of dropped files list, and the rest of the files will be loaded assuming they're media as previously

There is one known issue: If the settings window is open while the skins are being dropped, the skin list won't be updated.