### PR TITLE
sid: Add SID model(s) as comment

### DIFF
--- a/src/sid/xmms-sid.cc
+++ b/src/sid/xmms-sid.cc
@@ -225,6 +225,9 @@ static void xs_get_song_tuple_info(Tuple &tuple, const xs_tuneinfo_t &info, int 
     tuple.set_str (Tuple::Artist, info.sidComposer);
     tuple.set_str (Tuple::Copyright, info.sidCopyright);
     tuple.set_str (Tuple::Codec, info.sidFormat);
+    tuple.set_str (Tuple::Comment, info.nSIDs > 1
+        ? str_printf ("%s (%dSID)", (const char *) info.sidModel, info.nSIDs)
+        : info.sidModel);
 
     /* Get sub-tune information, if available */
     if (subTune < 0 || info.startTune > info.nsubTunes)

--- a/src/sid/xmms-sid.h
+++ b/src/sid/xmms-sid.h
@@ -43,8 +43,8 @@ struct xs_subtuneinfo_t
 
 struct xs_tuneinfo_t
 {
-    String sidName, sidComposer, sidCopyright, sidFormat;
-    int nsubTunes, startTune;
+    String sidName, sidComposer, sidCopyright, sidFormat, sidModel;
+    int nsubTunes, startTune, nSIDs;
     Index<xs_subtuneinfo_t> subTunes;
 };
 

--- a/src/sid/xs_sidplay2.cc
+++ b/src/sid/xs_sidplay2.cc
@@ -279,6 +279,14 @@ bool xs_sidplayfp_getinfo(xs_tuneinfo_t &ti, const void *buf, int64_t bufSize)
 
     ti.sidFormat = String (myInfo->formatString());
 
+    ti.nSIDs = myInfo->sidChips();
+    if (myInfo->sidModel(0) == SidTuneInfo::SIDMODEL_6581)
+        ti.sidModel = String ("MOS6581");
+    else if (myInfo->sidModel(0) == SidTuneInfo::SIDMODEL_8580)
+        ti.sidModel = String ("CSG8580");
+    else
+        ti.sidModel = String ();
+
     /* Fill in subtune information */
     ti.subTunes.insert(0, ti.nsubTunes);
 


### PR DESCRIPTION
also number of SIDs used (e.g. 2SID or 3SID tunes)