### PR TITLE
OpenPSF: Corrections for PS2 playback

### DIFF
--- a/src/psf/peops2/dma.cc
+++ b/src/psf/peops2/dma.cc
@@ -104,9 +104,41 @@ EXPORT_GCC void CALLBACK SPU2writeDMA4Mem(u32 usPSXMem,int iSize)
  int i;
  u16 *ram16 = (u16 *)&psx_ram[0];
 
+ // Some streaming drivers (such as FFIV's generic PS2 streaming
+ // driver) kick a single DMA transfer covering two back-to-back 16KB
+ // per-channel halves read from one shared read-ahead buffer, but
+ // only refill that buffer's first 16KB with genuinely fresh data each
+ // cycle - the second half is whatever was last (never, for a freshly
+ // allocated buffer) written there. Past the first 8192 words (16KB) of
+ // any transfer landing in a channel's own ring, treat an exact-zero
+ // source sample as "not actually new data" and leave the existing
+ // spuMem content alone rather than overwriting real audio with a
+ // spurious zero - the correct data for that position typically arrives
+ // one refill cycle later via the next kick's own first half anyway.
+ // Titles using >16KB transfers for genuinely fresh per-channel data
+ // never have an exactly-zero tail, so they are unaffected - this only
+ // skips the specific uninitialised-RAM-over-read case.
+ bool ch_ring_overlap = false;
+ {
+  u32 dest_start = spuAddr2[0]*2;
+  u32 dest_end = dest_start + (u32)iSize*2;
+  for (int c = 0; c < 2; c++)
+   {
+    uintptr_t pStart_off = (uintptr_t)(s_chan[c].pStart - spuMemC);
+    if (dest_end > pStart_off && dest_start < pStart_off + 0x20000)
+     {
+      ch_ring_overlap = true;
+     }
+   }
+ }
+
  for(i=0;i<iSize;i++)
   {
-   spuMem[spuAddr2[0]] = ram16[usPSXMem>>1];                 // spu addr 0 got by writeregister
+   u16 srcVal = ram16[usPSXMem>>1];
+   if (!(i >= 8192 && ch_ring_overlap && srcVal == 0))
+    {
+     spuMem[spuAddr2[0]] = srcVal;                            // spu addr 0 got by writeregister
+    }
    usPSXMem+=2;
    {
     u32 written_end = (spuAddr2[0]+1)*2;

--- a/src/psf/peops2/dma.cc
+++ b/src/psf/peops2/dma.cc
@@ -104,20 +104,19 @@ EXPORT_GCC void CALLBACK SPU2writeDMA4Mem(u32 usPSXMem,int iSize)
  int i;
  u16 *ram16 = (u16 *)&psx_ram[0];
 
- // Some streaming drivers (such as FFIV's generic PS2 streaming
- // driver) kick a single DMA transfer covering two back-to-back 16KB
- // per-channel halves read from one shared read-ahead buffer, but
- // only refill that buffer's first 16KB with genuinely fresh data each
- // cycle - the second half is whatever was last (never, for a freshly
- // allocated buffer) written there. Past the first 8192 words (16KB) of
- // any transfer landing in a channel's own ring, treat an exact-zero
- // source sample as "not actually new data" and leave the existing
- // spuMem content alone rather than overwriting real audio with a
- // spurious zero - the correct data for that position typically arrives
- // one refill cycle later via the next kick's own first half anyway.
- // Titles using >16KB transfers for genuinely fresh per-channel data
- // never have an exactly-zero tail, so they are unaffected - this only
- // skips the specific uninitialised-RAM-over-read case.
+ // Some streaming drivers (such as the generic PS2 streaming driver used for
+ // Final Fantasy IV) kick a single DMA transfer covering two back-to-back 16KB
+ // per-channel halves read from one shared read-ahead buffer, but only refill
+ // that buffer's first 16KB with genuinely fresh data each cycle - the second
+ // half is whatever was last (never, for a freshly allocated buffer) written
+ // there. Past the first 8192 words (16KB) of any transfer landing in a
+ // channel's own ring, treat an exact-zero source sample as 'not actually new
+ // data' and leave the existing spuMem content alone rather than overwriting
+ // real audio with a spurious zero - the correct data for that position
+ // typically arrives one refill cycle later via the next kick's own first half
+ // anyway. Titles using >16KB transfers for genuinely fresh per-channel data
+ // never have an exactly-zero tail, so they are unaffected - this only skips
+ // the specific uninitialised-RAM-over-read case.
  bool ch_ring_overlap = false;
  {
   u32 dest_start = spuAddr2[0]*2;

--- a/src/psf/peops2/dma.cc
+++ b/src/psf/peops2/dma.cc
@@ -108,9 +108,15 @@ EXPORT_GCC void CALLBACK SPU2writeDMA4Mem(u32 usPSXMem,int iSize)
   {
    spuMem[spuAddr2[0]] = ram16[usPSXMem>>1];                 // spu addr 0 got by writeregister
    usPSXMem+=2;
+   {
+    u32 written_end = (spuAddr2[0]+1)*2;
+    if (written_end > g_spuMem_write_high) g_spuMem_write_high = written_end;
+   }
    spuAddr2[0]++;                                      // inc spu addr
    if(spuAddr2[0]>0xfffff) spuAddr2[0]=0;              // wrap
   }
+
+ g_last_spu2_dma_sampcount = sampcount;
 
  iSpuAsyncWait=0;
 
@@ -126,9 +132,15 @@ EXPORT_GCC void CALLBACK SPU2writeDMA7Mem(u32 usPSXMem,int iSize)
  for(i=0;i<iSize;i++)
   {
    spuMem[spuAddr2[1]] = ram16[usPSXMem>>1];           // spu addr 1 got by writeregister
+   {
+    u32 written_end = (spuAddr2[1]+1)*2;
+    if (written_end > g_spuMem_write_high) g_spuMem_write_high = written_end;
+   }
    spuAddr2[1]++;                                      // inc spu addr
    if(spuAddr2[1]>0xfffff) spuAddr2[1]=0;              // wrap
   }
+
+ g_last_spu2_dma_sampcount = sampcount;
 
  iSpuAsyncWait=0;
 

--- a/src/psf/peops2/externals.h
+++ b/src/psf/peops2/externals.h
@@ -260,6 +260,10 @@ extern unsigned char * spuMemC;
 extern unsigned char * pSpuIrq[];
 extern unsigned char * pSpuBuffer;
 
+extern u32 sampcount;
+extern u32 g_last_spu2_dma_sampcount;
+extern u32 g_spuMem_write_high;
+
 // user settings
 
 extern int        iUseXA;

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -335,11 +335,11 @@ u32 sampcount;
 u32 g_last_spu2_dma_sampcount = 0;
 
 // Running high-water mark (byte offset into spuMemC) of the furthest point
-// any SPU2 DMA write has ever reached, updated from dma.cc. Lets the
-// ADPCM ring-wrap logic below tell "genuinely never-written memory" apart
-// from "real data that was written a while ago" - DMA write recency alone
-// isn't enough, since a normal fully-preloaded track has its whole body
-// written once, long before decode reaches the end of it.
+// any SPU2 DMA write has ever reached, updated from dma.cc. Lets the ADPCM
+// ring-wrap logic below tell 'genuinely never-written memory' apart from
+// 'real data that was written a while ago' - DMA write recency alone isn't
+// enough, since a normal fully-preloaded track has its whole body written
+// once, long before decode reaches the end of it.
 u32 g_spuMem_write_high = 0;
 
 static u32 decaybegin;
@@ -484,37 +484,35 @@ static void *MAINThread(void (*update)(const void *, int))
              // stall its refill logic indefinitely. Wrapping within pStart's
              // own window keeps the reported address sane instead.
              //
-             // But this only makes sense while the channel's data is
-             // genuinely being actively streamed in (fresh DMA writes still
-             // landing, as with the hacked Corlett streaming driver this was
-             // written for). A normal, fully-preloaded one-shot track (the common case -
-             // its whole body DMA'd in once, up front) has no more data
-             // coming, but "no recent DMA writes" does NOT mean "no more
-             // real data exists" - the entire track's content, however
-             // large, was typically already written in one early burst.
-             // Wrapping (or worse, stopping) purely because DMA has been
-             // quiet for a couple of seconds cuts a track off as soon as
-             // decode passes the 128KB mark even though hundreds of KB of
-             // legitimate, already-loaded audio still follow it (an earlier
-             // version of this fix that used DMA recency alone cut FFX-2's
-             // "Game Over"/"Good Night" off at ~9s instead of their real
-             // ~15s).
+             // But this only makes sense while the channel's data is genuinely
+             // being actively streamed in (fresh DMA writes still incoming, as
+             // with the hacked Corlett streaming driver this was written for).
+             // A normal, fully-preloaded one-shot track (the common case - its
+             // whole body DMA'd in once, up front) has no more data coming,
+             // but 'no recent DMA writes' does *not* mean 'no more real data
+             // exists' - the entire track's content, however large, was
+             // typically already written in one early burst. Wrapping (or
+             // worse, stopping) purely because DMA has been quiet for a couple
+             // of seconds cuts a track off as soon as decode passes the 128KB
+             // mark even though hundreds of KB of legitimate, already-loaded
+             // audio still follow it (an earlier version of this fix that used
+             // DMA recency alone cut short, non-looping tracks early, eg Final
+             // Fantasy X-2's Good Night and Game Over).
              //
              // The two cases need genuinely different handling, not just a
-             // blended condition - a single global "has anything, anywhere,
-             // ever been written this far into spuMem" watermark isn't
+             // blended condition - a single global 'has anything, anywhere,
+             // ever been written this far into spuMem' watermark isn't
              // enough on its own either: unrelated data elsewhere in spuMem
-             // (e.g. other channels' own preloaded samples) can push that
+             // (eg other channels' own preloaded samples) can push that
              // watermark well past an actively-streamed channel's own real
              // window, which then never gets its small-window wrap at all -
-             // silencing it instead (this broke FFIV's streaming fix on the
-             // first attempt at this approach). So: while DMA is
-             // actively landing, keep exactly the original pStart-relative
-             // window wrap unconditionally, unrelated to any watermark.
-             // Only once DMA has been idle for a while - meaning nothing
-             // will ever refill this window again - fall back to the
-             // watermark to tell "more of this track's own preloaded data
-             // follows" apart from "genuinely nothing left, stop".
+             // silencing it instead. So: while DMA is actively incoming, keep
+             // exactly the original pStart-relative window wrap
+             // unconditionally, unrelated to any watermark. Only once DMA has
+             // been idle for a while - meaning nothing will ever refill this
+             // window again - fall back to the watermark to tell 'more of this
+             // track's own preloaded data follows' apart from 'genuinely
+             // nothing left, stop'.
              {
               const uintptr_t ring_size = 0x20000;
               const u32 dma_idle_samples = 2*44100;
@@ -904,12 +902,17 @@ ENDX:   ;
     // block's worth of time from the output entirely: playback progress is
     // tracked by how much audio has been delivered, not a fixed wall-clock
     // timer, so any dropped block shortens the track. A real rest in the
-    // music still takes real time to "play" on real hardware; the previous
-    // discard heuristic (originally a "don't bother sending silence"
-    // optimization, and before that even cruder - checking the combined
+    // music still takes real time to 'play' on real hardware; the previous
+    // discard heuristic (originally a 'don't bother sending silence'
+    // optimisation, and before that even cruder - checking the combined
     // L+R buffer as one pool) caused a systematic, cumulative duration
     // shortfall for any track with real pauses/quiet passages, scattered
     // throughout the track rather than just at its start or end.
+
+    // Side-effect as yet unresolved: the drop-silence heuristic was masking a
+    // deficiency in scheduler fairness that resulted in cycles being spent
+    // stuck idle, resulting in start-up silence of the order of 1-3 seconds
+    // for most tracks.
     update((u8*)pSpuBuffer,(u8*)pS-(u8*)pSpuBuffer);
 
     pS=(short *)pSpuBuffer;

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -96,6 +96,7 @@
 //*************************************************************************//
 
 #include "stdafx.h"
+#include <stdint.h>
 
 #define _IN_SPU
 
@@ -456,16 +457,20 @@ static void *MAINThread(void (*update)(const void *, int))
 
              // A channel with no valid stop/loop flag in its stream (or one
              // whose stream ran out without being refilled) would otherwise
-             // have pCurr walk straight off the end of the 2MB spuMem
-             // buffer with no bounds check at all, reading whatever memory
-             // happens to follow it in the process. Treat running outside
-             // the buffer the same as the explicit stop sentinel above.
+             // have pCurr walk straight off the end of the 2MB spuMem buffer
+             // with no bounds check at all, reading whatever memory happens
+             // to follow it in the process. spuMem is addressed by real SPU2
+             // hardware as fixed-size RAM whose address naturally wraps on
+             // overflow, so mirror that instead of stopping the channel:
+             // wrapping is what lets a streaming driver's own read-ahead
+             // logic (which polls the voice's address via sceSdGetAddr to
+             // decide when to request more data) keep seeing progress.
              if (start < spuMemC || start >= spuMemC + sizeof(spuMem))
               {
-               s_chan[ch].bOn=0;
-               s_chan[ch].ADSRX.lVolume=0;
-               s_chan[ch].ADSRX.EnvelopeVol=0;
-               goto ENDX;
+               uintptr_t off = (uintptr_t)(start - spuMemC);
+               off &= (sizeof(spuMem) - 1);
+               start = spuMemC + off;
+               s_chan[ch].pCurr = start;
               }
 
              s_chan[ch].iSBPos=0;

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -805,25 +805,18 @@ ENDX:   ;
    }
   else if((((u8*)pS)-((u8*)pSpuBuffer)) == (735*4))
    {
-    // Check each stereo channel's silence independently: a block should
-    // only be dropped as "not worth delivering" if BOTH channels are
-    // mostly silent. Checking the interleaved L+R buffer as one pool (as
-    // this used to) means one channel being legitimately silent (e.g. a
-    // mono voice, or a channel that has run out of streamed data) is
-    // enough on its own to discard the other channel's live audio too.
-    short *pSilenceIter = (short *)pSpuBuffer;
-    int iSilenceCountL = 0, iSilenceCountR = 0;
-
-    for(; pSilenceIter < pS; pSilenceIter += 2)
-     {
-      if(pSilenceIter[0] == 0)
-       iSilenceCountL++;
-      if(pSilenceIter[1] == 0)
-       iSilenceCountR++;
-     }
-
-    if(iSilenceCountL < 20 || iSilenceCountR < 20)
-     update((u8*)pSpuBuffer,(u8*)pS-(u8*)pSpuBuffer);
+    // Always deliver every block, silent or not. Skipping a block - even a
+    // genuinely, fully silent one - doesn't just mute it, it erases that
+    // block's worth of time from the output entirely: playback progress is
+    // tracked by how much audio has been delivered, not a fixed wall-clock
+    // timer, so any dropped block shortens the track. A real rest in the
+    // music still takes real time to "play" on real hardware; the previous
+    // discard heuristic (originally a "don't bother sending silence"
+    // optimization, and before that even cruder - checking the combined
+    // L+R buffer as one pool) caused a systematic, cumulative duration
+    // shortfall for any track with real pauses/quiet passages, scattered
+    // throughout the track rather than just at its start or end.
+    update((u8*)pSpuBuffer,(u8*)pS-(u8*)pSpuBuffer);
 
     pS=(short *)pSpuBuffer;
    }

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -476,6 +476,27 @@ static void *MAINThread(void (*update)(const void *, int))
                 uintptr_t off = (uintptr_t)(start - s_chan[ch].pStart);
                 off &= (ring_size - 1);
                 start = s_chan[ch].pStart + off;
+
+                // pStart itself is driver/register-controlled (a real, in-spec
+                // 20-bit start address can legitimately sit as little as 2
+                // bytes from the end of the 2MB spuMem array), so pStart's own
+                // ring_size window can extend past the real buffer even after
+                // the wrap above. There's no sane data to continue decoding
+                // from in that case (wrapping to some arbitrary offset in
+                // spuMem would just play back whatever unrelated bytes happen
+                // to live there, likely never hitting a real stop/loop flag -
+                // a stuck/hung note instead of a crash). Treat it the same as
+                // the sentinel stop condition instead: it's a genuine
+                // out-of-range address, not a legitimate case to keep playing.
+                if (start < spuMemC || start >= spuMemC + sizeof(spuMem))
+                 {
+                  s_chan[ch].bOn=0;
+                  s_chan[ch].ADSRX.lVolume=0;
+                  s_chan[ch].ADSRX.EnvelopeVol=0;
+                  s_chan[ch].pCurr=(unsigned char*)-1;
+                  goto ENDX;
+                 }
+
                 s_chan[ch].pCurr = start;
                }
              }

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -459,19 +459,26 @@ static void *MAINThread(void (*update)(const void *, int))
              // whose stream ran out without being refilled) would otherwise
              // have pCurr walk straight off the end of the 2MB spuMem buffer
              // with no bounds check at all, reading whatever memory happens
-             // to follow it in the process. spuMem is addressed by real SPU2
-             // hardware as fixed-size RAM whose address naturally wraps on
-             // overflow, so mirror that instead of stopping the channel:
-             // wrapping is what lets a streaming driver's own read-ahead
-             // logic (which polls the voice's address via sceSdGetAddr to
-             // decide when to request more data) keep seeing progress.
-             if (start < spuMemC || start >= spuMemC + sizeof(spuMem))
-              {
-               uintptr_t off = (uintptr_t)(start - spuMemC);
-               off &= (sizeof(spuMem) - 1);
-               start = spuMemC + off;
-               s_chan[ch].pCurr = start;
-              }
+             // to follow it in the process. Streaming drivers built around
+             // sceSdGetAddr-style read-ahead accounting (this one included)
+             // expect a voice's reported address to stay within its own
+             // buffer window, anchored at pStart - letting it grow across
+             // the whole 2MB spuMem array (even just as a safety wrap) feeds
+             // that accounting values far outside the range it was designed
+             // for, which can saturate a driver's own clamped arithmetic and
+             // stall its refill logic indefinitely. Wrapping within pStart's
+             // own window keeps the reported address sane instead.
+             {
+              const uintptr_t ring_size = 0x20000;
+              if (start < s_chan[ch].pStart || start >= s_chan[ch].pStart + ring_size
+                  || start < spuMemC || start >= spuMemC + sizeof(spuMem))
+               {
+                uintptr_t off = (uintptr_t)(start - s_chan[ch].pStart);
+                off &= (ring_size - 1);
+                start = s_chan[ch].pStart + off;
+                s_chan[ch].pCurr = start;
+               }
+             }
 
              s_chan[ch].iSBPos=0;
 

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -326,7 +326,22 @@ static inline void StartSound(int ch)
 // basically the whole sound processing is done in this fat func!
 ////////////////////////////////////////////////////////////////////////
 
-static u32 sampcount;
+u32 sampcount;
+
+// Song-time (in sampcount units) of the most recent SPU2 DMA write, updated
+// from dma.cc. Used by the ADPCM ring-wrap logic below to tell an actively-
+// streamed voice (fresh data still arriving) apart from a fully-preloaded
+// one whose data simply ran out.
+u32 g_last_spu2_dma_sampcount = 0;
+
+// Running high-water mark (byte offset into spuMemC) of the furthest point
+// any SPU2 DMA write has ever reached, updated from dma.cc. Lets the
+// ADPCM ring-wrap logic below tell "genuinely never-written memory" apart
+// from "real data that was written a while ago" - DMA write recency alone
+// isn't enough, since a normal fully-preloaded track has its whole body
+// written once, long before decode reaches the end of it.
+u32 g_spuMem_write_high = 0;
+
 static u32 decaybegin;
 static u32 decayend;
 
@@ -468,36 +483,94 @@ static void *MAINThread(void (*update)(const void *, int))
              // for, which can saturate a driver's own clamped arithmetic and
              // stall its refill logic indefinitely. Wrapping within pStart's
              // own window keeps the reported address sane instead.
+             //
+             // But this only makes sense while the channel's data is
+             // genuinely being actively streamed in (fresh DMA writes still
+             // landing, as with the hacked Corlett streaming driver this was
+             // written for). A normal, fully-preloaded one-shot track (the common case -
+             // its whole body DMA'd in once, up front) has no more data
+             // coming, but "no recent DMA writes" does NOT mean "no more
+             // real data exists" - the entire track's content, however
+             // large, was typically already written in one early burst.
+             // Wrapping (or worse, stopping) purely because DMA has been
+             // quiet for a couple of seconds cuts a track off as soon as
+             // decode passes the 128KB mark even though hundreds of KB of
+             // legitimate, already-loaded audio still follow it (an earlier
+             // version of this fix that used DMA recency alone cut FFX-2's
+             // "Game Over"/"Good Night" off at ~9s instead of their real
+             // ~15s).
+             //
+             // The two cases need genuinely different handling, not just a
+             // blended condition - a single global "has anything, anywhere,
+             // ever been written this far into spuMem" watermark isn't
+             // enough on its own either: unrelated data elsewhere in spuMem
+             // (e.g. other channels' own preloaded samples) can push that
+             // watermark well past an actively-streamed channel's own real
+             // window, which then never gets its small-window wrap at all -
+             // silencing it instead (this broke FFIV's streaming fix on the
+             // first attempt at this approach). So: while DMA is
+             // actively landing, keep exactly the original pStart-relative
+             // window wrap unconditionally, unrelated to any watermark.
+             // Only once DMA has been idle for a while - meaning nothing
+             // will ever refill this window again - fall back to the
+             // watermark to tell "more of this track's own preloaded data
+             // follows" apart from "genuinely nothing left, stop".
              {
               const uintptr_t ring_size = 0x20000;
-              if (start < s_chan[ch].pStart || start >= s_chan[ch].pStart + ring_size
-                  || start < spuMemC || start >= spuMemC + sizeof(spuMem))
-               {
-                uintptr_t off = (uintptr_t)(start - s_chan[ch].pStart);
-                off &= (ring_size - 1);
-                start = s_chan[ch].pStart + off;
+              const u32 dma_idle_samples = 2*44100;
+              bool dma_recently_active = (sampcount - g_last_spu2_dma_sampcount) < dma_idle_samples;
 
-                // pStart itself is driver/register-controlled (a real, in-spec
-                // 20-bit start address can legitimately sit as little as 2
-                // bytes from the end of the 2MB spuMem array), so pStart's own
-                // ring_size window can extend past the real buffer even after
-                // the wrap above. There's no sane data to continue decoding
-                // from in that case (wrapping to some arbitrary offset in
-                // spuMem would just play back whatever unrelated bytes happen
-                // to live there, likely never hitting a real stop/loop flag -
-                // a stuck/hung note instead of a crash). Treat it the same as
-                // the sentinel stop condition instead: it's a genuine
-                // out-of-range address, not a legitimate case to keep playing.
-                if (start < spuMemC || start >= spuMemC + sizeof(spuMem))
+              if (dma_recently_active)
+               {
+                bool out_of_window = (start < s_chan[ch].pStart || start >= s_chan[ch].pStart + ring_size
+                    || start < spuMemC || start >= spuMemC + sizeof(spuMem));
+                if (out_of_window)
                  {
+                  uintptr_t off = (uintptr_t)(start - s_chan[ch].pStart);
+                  off &= (ring_size - 1);
+                  start = s_chan[ch].pStart + off;
+
+                  // pStart itself is driver/register-controlled (a real, in-spec
+                  // 20-bit start address can legitimately sit as little as 2
+                  // bytes from the end of the 2MB spuMem array), so pStart's own
+                  // ring_size window can extend past the real buffer even after
+                  // the wrap above. There's no sane data to continue decoding
+                  // from in that case (wrapping to some arbitrary offset in
+                  // spuMem would just play back whatever unrelated bytes happen
+                  // to live there, likely never hitting a real stop/loop flag -
+                  // a stuck/hung note instead of a crash). Treat it the same as
+                  // the sentinel stop condition instead: it's a genuine
+                  // out-of-range address, not a legitimate case to keep playing.
+                  if (start < spuMemC || start >= spuMemC + sizeof(spuMem))
+                   {
+                    s_chan[ch].bOn=0;
+                    s_chan[ch].ADSRX.lVolume=0;
+                    s_chan[ch].ADSRX.EnvelopeVol=0;
+                    s_chan[ch].pCurr=(unsigned char*)-1;
+                    goto ENDX;
+                   }
+
+                  s_chan[ch].pCurr = start;
+                 }
+               }
+              else
+               {
+                bool beyond_written_data = (start < spuMemC) || (start >= spuMemC + sizeof(spuMem))
+                    || ((u32)(start - spuMemC) >= g_spuMem_write_high);
+                if (beyond_written_data)
+                 {
+                  // Nothing has ever been written this far into spuMem, and
+                  // no new data has landed recently either - there's
+                  // genuinely nothing left to read. End the channel
+                  // cleanly, same as the sentinel stop condition above.
                   s_chan[ch].bOn=0;
                   s_chan[ch].ADSRX.lVolume=0;
                   s_chan[ch].ADSRX.EnvelopeVol=0;
                   s_chan[ch].pCurr=(unsigned char*)-1;
                   goto ENDX;
                  }
-
-                s_chan[ch].pCurr = start;
+                // else: real, already-written data still follows - keep
+                // reading it as-is, no wrap needed.
                }
              }
 

--- a/src/psf/peops2/spu.cc
+++ b/src/psf/peops2/spu.cc
@@ -454,6 +454,20 @@ static void *MAINThread(void (*update)(const void *, int))
                goto ENDX;                              // -> and done for this channel
               }
 
+             // A channel with no valid stop/loop flag in its stream (or one
+             // whose stream ran out without being refilled) would otherwise
+             // have pCurr walk straight off the end of the 2MB spuMem
+             // buffer with no bounds check at all, reading whatever memory
+             // happens to follow it in the process. Treat running outside
+             // the buffer the same as the explicit stop sentinel above.
+             if (start < spuMemC || start >= spuMemC + sizeof(spuMem))
+              {
+               s_chan[ch].bOn=0;
+               s_chan[ch].ADSRX.lVolume=0;
+               s_chan[ch].ADSRX.EnvelopeVol=0;
+               goto ENDX;
+              }
+
              s_chan[ch].iSBPos=0;
 
              //////////////////////////////////////////// spu irq handler here? mmm... do it later
@@ -779,19 +793,24 @@ ENDX:   ;
    }
   else if((((u8*)pS)-((u8*)pSpuBuffer)) == (735*4))
    {
+    // Check each stereo channel's silence independently: a block should
+    // only be dropped as "not worth delivering" if BOTH channels are
+    // mostly silent. Checking the interleaved L+R buffer as one pool (as
+    // this used to) means one channel being legitimately silent (e.g. a
+    // mono voice, or a channel that has run out of streamed data) is
+    // enough on its own to discard the other channel's live audio too.
     short *pSilenceIter = (short *)pSpuBuffer;
-    int iSilenceCount = 0;
+    int iSilenceCountL = 0, iSilenceCountR = 0;
 
-    for(; pSilenceIter < pS; pSilenceIter++)
+    for(; pSilenceIter < pS; pSilenceIter += 2)
      {
-      if(*pSilenceIter == 0)
-       iSilenceCount++;
-
-      if(iSilenceCount > 20)
-       break;
+      if(pSilenceIter[0] == 0)
+       iSilenceCountL++;
+      if(pSilenceIter[1] == 0)
+       iSilenceCountR++;
      }
 
-    if(iSilenceCount < 20)
+    if(iSilenceCountL < 20 || iSilenceCountR < 20)
      update((u8*)pSpuBuffer,(u8*)pS-(u8*)pSpuBuffer);
 
     pS=(short *)pSpuBuffer;

--- a/src/psf/psx.cc
+++ b/src/psf/psx.cc
@@ -761,8 +761,16 @@ int mips_execute( int cycles )
 		case OP_ADDIU:
 			if (INS_RT( mipscpu.op ) == 0)
 			{
-				psx_iop_call(mipscpu.pc, INS_IMMEDIATE(mipscpu.op));
-				mips_advance_pc();
+				// psx_iop_call() may switch mipscpu to a different thread
+				// entirely (see its own comment in psx_hw.cc); in that
+				// case it returns 0 and has already handled whatever
+				// bookkeeping the ORIGINAL calling thread needed, so we
+				// must not call mips_advance_pc() here - it would apply
+				// to whichever thread is now live instead.
+				if (psx_iop_call(mipscpu.pc, INS_IMMEDIATE(mipscpu.op)))
+				{
+					mips_advance_pc();
+				}
 			}
 			else
 			{

--- a/src/psf/psx.cc
+++ b/src/psf/psx.cc
@@ -252,7 +252,11 @@ static inline void mips_set_cp0r( int reg, uint32_t value )
 
 static inline void mips_commit_delayed_load( void )
 {
-	if( mipscpu.delayr != 0 )
+	// delayr can also hold the REGPC sentinel (a pending delayed *branch*,
+	// not a pending register load) - mips_delayed_branch() calls this
+	// unconditionally when a branch sits in another branch's delay slot,
+	// so this must not treat REGPC as a real register index.
+	if( mipscpu.delayr != 0 && mipscpu.delayr != REGPC )
 	{
 		mipscpu.r[ mipscpu.delayr ] = mipscpu.delayv;
 		mipscpu.delayr = 0;

--- a/src/psf/psx.h
+++ b/src/psf/psx.h
@@ -347,6 +347,6 @@ void program_write_byte_32le(offs_t address, uint8_t data);
 void program_write_word_32le(offs_t address, uint16_t data);
 void program_write_dword_32le(offs_t address, uint32_t data);
 
-void psx_iop_call(uint32_t pc, uint32_t callnum);
+uint32_t psx_iop_call(uint32_t pc, uint32_t callnum);
 
 #endif

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -182,6 +182,7 @@ typedef struct
 static Counter root_cnts[4];	// 4 of the bastards
 
 #define CLOCK_DIV	(8)	// 33 MHz / this = what we run the R3000 at to keep the CPU usage not insane
+#define IOP_CYCLES_PER_SAMPLE	(836)	// raw (undivided) IOP clock cycles per PS2 audio sample: 36864000 Hz (768*48000) / 44100 Hz
 
 // counter modes
 #define RC_EN		(0x0001)	// halt
@@ -872,7 +873,7 @@ void ps2_hw_slice(void)
 
 	if (iCurThread != -1)
 	{
-		mips_execute(836/CLOCK_DIV);
+		mips_execute(IOP_CYCLES_PER_SAMPLE/CLOCK_DIV);
 	}
 	else	// no thread, don't run CPU, just update counters
 	{
@@ -882,8 +883,8 @@ void ps2_hw_slice(void)
 
 			if (iCurThread != -1)
 			{
-				mips_execute((836/CLOCK_DIV)-i);
-				i = (836/CLOCK_DIV);
+				mips_execute((IOP_CYCLES_PER_SAMPLE/CLOCK_DIV)-i);
+				i = (IOP_CYCLES_PER_SAMPLE/CLOCK_DIV);
 			}
 		}
 	}
@@ -1892,7 +1893,7 @@ void psx_hw_runcounters(void)
 			}
 		}
 
-		sys_time += 836;
+		sys_time += IOP_CYCLES_PER_SAMPLE;
 
 		if (iNumTimers > 0)
 		{
@@ -1900,7 +1901,7 @@ void psx_hw_runcounters(void)
 			{
 				if (iop_timers[i].iActive > 0)
 				{
-					iop_timers[i].count += 836;
+					iop_timers[i].count += IOP_CYCLES_PER_SAMPLE;
 					if (iop_timers[i].count >= iop_timers[i].target)
 					{
 						iop_timers[i].count -= iop_timers[i].target;

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -277,28 +277,26 @@ static void FreezeThread(int32_t iThread, int flag)
 	}
 	threads[iThread].save_regs[34] = mipsinfo.i;
 
-	// Every HLE syscall that can freeze its own thread (flag=1) is only
-	// ever reached through psx_iop_call(), which is itself only ever
-	// invoked from the interpreter's "addiu $0,N with rt==0" special case
-	// - and by this codebase's own generated-code convention, that
-	// instruction is always the delay slot of an immediately-preceding
-	// "jr $ra" (the return half of every IOP export-table stub: "jr $ra;
-	// addiu $0,callnum"). So whenever a blocking syscall (DelayThread,
-	// WaitSema, SleepThread, etc.) fires from exactly this position,
-	// mipscpu.delayr is already REGPC (a still-uncommitted pending branch
-	// from that jr) and mipscpu.delayv already equals $ra - the same
-	// value just captured above into save_regs[34]. The delayr/delayv
-	// snapshot taken above therefore describes a branch that's redundant
-	// with the resume PC we're about to restore on thaw, not a second,
-	// independent piece of state: left in place, ThawThread() correctly
-	// sets PC to save_regs[34] but ALSO restores this stale "still
+	// Every HLE syscall that can freeze its own thread (flag=1) is only ever
+	// reached through psx_iop_call(), which is itself only ever invoked from
+	// the interpreter's "addiu $0,N with rt==0" special case - and by this
+	// code base's own generated-code convention, that instruction is always
+	// the delay slot of an immediately-preceding "jr $ra" (the return half of
+	// every IOP export-table stub: "jr $ra; addiu $0,callnum"). So whenever a
+	// blocking syscall (DelayThread, WaitSema, SleepThread, etc.) fires from
+	// exactly this position, mipscpu.delayr is already REGPC (a still-
+	// uncommitted pending branch from that jr) and mipscpu.delayv already
+	// equals $ra - the same value just captured above into save_regs[34]. The
+	// delayr/delayv snapshot taken above therefore describes a branch that's
+	// redundant with the resume PC we're about to restore on thaw, not a
+	// second, independent piece of state: left in place, ThawThread()
+	// correctly sets PC to save_regs[34] but ALSO restores this stale "still
 	// pending" branch, which then wrongly re-fires on the very next
-	// instruction's delay-slot commit instead of letting execution
-	// advance normally - silently diverting control flow into whatever
-	// memory that references, including non-code data if the resumed
-	// thread wasn't expecting a jump there at all. Clear it in this
-	// specific, provably-safe case - the resume PC already captures its
-	// effect.
+	// instruction's delay-slot commit instead of letting execution advance
+	// normally - silently diverting control flow into whatever memory that
+	// references, including non-code data if the resumed thread wasn't
+	// expecting a jump there at all. Clear it in this specific, provably-safe
+	// case - the resume PC already captures its effect.
 	if (flag && threads[iThread].save_regs[36] == 32)	// 32 == psx.cc's REGPC sentinel, not exposed via psx.h
 	{
 		threads[iThread].save_regs[35] = 0;
@@ -400,12 +398,12 @@ static void ps2_reschedule(void)
 
 	starti = i;
 
-	// Starting with the next thread after this one, scan the whole
-	// thread list (wrapping around) for the most urgent (lowest
-	// priority value) ready thread. Round-robin scan order is the
-	// tie-break among equal priorities (strict "<" below means an
-	// equal-priority later candidate never displaces an earlier one),
-	// matching prior behavior when priority doesn't distinguish them.
+	// Starting with the next thread after this one, scan the whole thread list
+	// (wrapping around) for the most urgent (lowest priority value) ready
+	// thread. Round-robin scan order is the tie-break among equal priorities
+	// (strict "<" below means an equal-priority later candidate never
+	// displaces an earlier one), matching prior behaviour when priority
+	// doesn't distinguish them.
 	while (i < iNumThreads)
 	{
 		if (i != iCurThread)
@@ -435,13 +433,13 @@ static void ps2_reschedule(void)
 		}
 	}
 
-	// A thread that's still actively running (hasn't voluntarily
-	// blocked/slept/exited before this call) only yields to a
-	// STRICTLY more urgent candidate - an equal-or-less-urgent ready
-	// thread waits its turn instead of preempting mid-work. A thread
-	// that already left TS_RUNNING (blocked itself before calling
-	// this) still switches to the best available candidate
-	// unconditionally, same as prior behavior for that case.
+	// A thread that's still actively running (hasn't voluntarily blocked/
+	// slept/exited before this call) only yields to a *strictly* more
+	// urgent candidate - an equal-or-less-urgent ready thread waits its
+	// turn instead of pre-empting mid-work. A thread that already left
+	// TS_RUNNING (blocked itself before calling this) still switches to the
+	// best available candidate unconditionally, same as prior behaviour for
+	// that case.
 	if (iNextThread != -1 && iCurThread != -1 && threads[iCurThread].iState == TS_RUNNING)
 	{
 		if (bestPriority >= threads[iCurThread].priority)
@@ -1054,16 +1052,16 @@ static void call_irq_routine(uint32_t routine, uint32_t parameter)
 	{
 		// A softcall hands the interpreter straight to driver code with a
 		// synthetic $ra trap and just spins until that trap fires. A driver
-		// routine that derails (e.g. runs off into non-code memory and never
+		// routine that derails (eg runs off into non-code memory and never
 		// executes the trap instruction) turns this into an unbounded spin
 		// at 100% CPU with no way for the user to recover short of killing
-		// the process (FFX-2's Crimson Squad hits this). Cap the
-		// wait so a misbehaving handler is abandoned instead of hanging
-		// for ever. The budget needs to stay generous, though: a smaller
-		// 10000-cycle cap tried initially cut off legitimately slow (but
-		// working) handlers mid-execution, which silenced FFX-2's Game
-		// Over and Good Night for the rest of playback even though they
-		// play back correctly given enough cycles to finish.
+		// the process (for example, the entire Final Fantasy X set, and Final
+		// Fantasy X-2's Crimson Squad). Cap the wait so a misbehaving handler
+		// is abandoned instead of hanging for ever. The budget needs to stay
+		// generous, though: a smaller 10000-cycle cap tried initially cut off
+		// legitimately slow (but working) handlers mid-execution, which
+		// silenced FFX-2's Game Over and Good Night for the rest of playback
+		// even though they play back correctly given enough cycles to finish.
 		uint64_t softcall_cycles = 0;
 		while (!softcall_target)
 		{
@@ -1982,12 +1980,11 @@ void psx_hw_runcounters(void)
 		{
 			if (threads[i].iState == TS_WAITDELAY)
 			{
-				// waitparm is set (in DelayThread) in raw IOP clock
-				// cycles at the true 36864000 Hz rate; each sample
-				// represents IOP_CYCLES_PER_SAMPLE of those, not
-				// CLOCK_DIV - the latter was off by ~104x, making
-				// every delay-based wait take that much longer than
-				// requested.
+				// waitparm is set (in DelayThread) in raw IOP clock cycles at
+				// the true 36864000 Hz rate; each sample represents
+				// IOP_CYCLES_PER_SAMPLE of those, not CLOCK_DIV - the latter
+				// was off by ~104x, making every delay-based wait take that
+				// much longer than requested.
 				if (threads[i].waitparm > IOP_CYCLES_PER_SAMPLE)
 				{
 					threads[i].waitparm -= IOP_CYCLES_PER_SAMPLE;
@@ -2704,11 +2701,11 @@ static void psx_iop_call_impl(uint32_t pc, uint32_t callnum)
 					{
 						threads[i].iState = TS_READY;
 						// The woken thread's own WaitSema call is finally
-						// completing successfully - set its saved $v0
-						// directly (it's not the live/current thread right
-						// now), so it sees the correct return value once
-						// actually thawed. See WaitSema's own comment for
-						// why this can no longer be set from there.
+						// completing successfully - set its saved $v0 directly
+						// (it's not the live/current thread right now), so it
+						// sees the correct return value once actually thawed.
+						// See WaitSema's own comment for why this can no
+						// longer be set from there.
 						threads[i].save_regs[2] = 0;
 						semaphores[a0].threadsWaiting--;
 						foundthread = 1;
@@ -3642,42 +3639,41 @@ static void psx_iop_call_impl(uint32_t pc, uint32_t callnum)
 
 // psx_iop_call_impl()'s registered-library and ELF-loader dispatch paths
 // (search this file for "NOTE: we get called in the delay slot!") set
-// mipscpu's PC to (target - 4), deliberately relying on the caller
-// (psx.cc's OP_ADDIU case) to complete the jump with its own subsequent
+// mipscpu's PC to (target - 4), deliberately relying on the caller (psx.cc's
+// OP_ADDIU case) to complete the jump with its own subsequent
 // mips_advance_pc() call, which adds the final +4. That works as long as
-// mipscpu still belongs to the SAME thread that made this call by the
-// time the caller's advance runs.
+// mipscpu still belongs to the SAME thread that made this call by the time the
+// caller's advance runs.
 //
 // But psx_iop_call_impl() can also, via a blocking syscall (DelayThread,
 // WaitSema, SleepThread, etc.) OR via any HLE handler that itself calls
-// ps2_reschedule() as routine bookkeeping (e.g. waking a higher-priority
-// thread), end up freezing the calling thread and switching to a
-// DIFFERENT one entirely - at which point mipscpu belongs to that other
-// thread, not the caller. Blindly letting the caller's mips_advance_pc()
-// run in that case corrupts whichever thread is now active (this is what
-// permanently truncated Vegnagun Starting's table-copy loop: the extra
-// advance skipped that thread's own pending loop-continuation branch
-// without ever evaluating it). But blindly SKIPPING the caller's advance
-// whenever any switch happens is ALSO wrong (this was tried and caused
-// total silence): if the calling thread got frozen via the generic
-// flag=0 path (not a $ra-based blocking syscall), its OWN saved PC is
-// exactly the pending "target-4" state above, still missing its +4 - and
-// if nothing ever completes that +4, the thread resumes 4 bytes short
-// the next time it's thawed.
+// ps2_reschedule() as routine bookkeeping (eg waking a higher-priority
+// thread), end up freezing the calling thread and switching to a DIFFERENT one
+// entirely - at which point mipscpu belongs to that other thread, not the
+// caller. Blindly letting the caller's mips_advance_pc() run in that case
+// corrupts whichever thread is now active (this is what permanently truncated
+// Final Fantasy X-2's Vegnagun Starting's table-copy loop: the extra advance
+// skipped that thread's own pending loop-continuation branch without ever
+// evaluating it). But blindly SKIPPING the caller's advance whenever any
+// switch happens is ALSO wrong (this was tried and caused total silence): if
+// the calling thread got frozen via the generic flag=0 path (not a $ra-based
+// blocking syscall), its OWN saved PC is exactly the pending "target-4" state
+// above, still missing its +4 - and if nothing ever completes that +4, the
+// thread resumes 4 bytes short the next time it's thawed.
 //
-// So: track whether a switch happened, and if so, look at how the
-// calling thread was actually frozen (recorded in Thread::lastFreezeFlag
-// by FreezeThread() itself) to decide what to do with ITS OWN saved
-// state specifically, independent of whichever thread is now live:
-//   - flag=1 (syscall/$ra-based): the calling thread's real resume point
-//     is $ra, already fully correct - the pending "target-4" pc doesn't
-//     matter to it at all. Nothing to fix.
-//   - flag=0 (generic/pc-based): the calling thread's saved pc IS the
-//     pending "target-4" state - complete it directly on its saved
-//     registers, since mipscpu no longer represents it.
+// So: track whether a switch happened, and if so, look at how the calling
+// thread was actually frozen (recorded in Thread::lastFreezeFlag by
+// FreezeThread() itself) to decide what to do with ITS OWN saved state
+// specifically, independent of whichever thread is now live:
+//   - flag=1 (syscall/$ra-based): the calling thread's real resume point is
+//     $ra, already fully correct - the pending "target-4" pc doesn't matter
+//     to it at all. Nothing to fix.
+//   - flag=0 (generic/pc-based): the calling thread's saved pc IS the pending
+//     "target-4" state - complete it directly on its saved registers, since
+//     mipscpu no longer represents it.
 // Either way, tell the caller NOT to run its own mips_advance_pc(), since
-// mipscpu now belongs to a different thread than the one that made this
-// call, and that thread's own execution must not be touched by it.
+// mipscpu now belongs to a different thread than the one that made this call,
+// and that thread's own execution must not be touched by it.
 uint32_t psx_iop_call(uint32_t pc, uint32_t callnum)
 {
 	int32_t origThread = iCurThread;
@@ -3686,9 +3682,9 @@ uint32_t psx_iop_call(uint32_t pc, uint32_t callnum)
 
 	if (iCurThread == origThread)
 	{
-		// No net switch away from the calling thread (including having
-		// been frozen and thawed straight back to itself) - mipscpu is
-		// still (or once again) its own context, so the caller's normal
+		// No net switch away from the calling thread (including having been
+		// frozen and thawed straight back to itself) - mipscpu is still (or
+		// once again) its own context, so the caller's normal
 		// mips_advance_pc() applies correctly, exactly as before.
 		return 1;
 	}
@@ -3700,4 +3696,3 @@ uint32_t psx_iop_call(uint32_t pc, uint32_t callnum)
 
 	return 0;
 }
-

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -992,12 +992,16 @@ static void call_irq_routine(uint32_t routine, uint32_t parameter)
 		// at 100% CPU with no way for the user to recover short of killing
 		// the process (FFX-2's Crimson Squad hits this). Cap the
 		// wait so a misbehaving handler is abandoned instead of hanging
-		// for ever - real handlers return within a tiny fraction of this.
+		// for ever. The budget needs to stay generous, though: a smaller
+		// 10000-cycle cap tried initially cut off legitimately slow (but
+		// working) handlers mid-execution, which silenced FFX-2's Game
+		// Over and Good Night for the rest of playback even though they
+		// play back correctly given enough cycles to finish.
 		uint64_t softcall_cycles = 0;
 		while (!softcall_target)
 		{
 			softcall_cycles += mips_execute(10);
-			if (softcall_cycles > 10000)
+			if (softcall_cycles > 40960)
 			{
 				fprintf(stderr, "IOP: ERROR! IRQ handler at %08x never returned - abandoning softcall\n", routine);
 				break;
@@ -1078,7 +1082,7 @@ static void psx_bios_exception(uint32_t pc)
 						while (!softcall_target)
 						{
 							softcall_cycles += mips_execute(10);
-							if (softcall_cycles > 10000)
+							if (softcall_cycles > 40960)
 							{
 								fprintf(stderr, "IOP: ERROR! VBlank handler never returned - abandoning softcall\n");
 								break;
@@ -1119,7 +1123,7 @@ static void psx_bios_exception(uint32_t pc)
 								while (!softcall_target)
 								{
 									softcall_cycles += mips_execute(10);
-									if (softcall_cycles > 10000)
+									if (softcall_cycles > 40960)
 									{
 										fprintf(stderr, "IOP: ERROR! root counter %d handler never returned - abandoning softcall\n", i);
 										break;

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -984,9 +984,25 @@ static void call_irq_routine(uint32_t routine, uint32_t parameter)
 
 	softcall_target = 0;
 	oldICount = mips_get_icount();
-	while (!softcall_target)
 	{
-		mips_execute(10);
+		// A softcall hands the interpreter straight to driver code with a
+		// synthetic $ra trap and just spins until that trap fires. A driver
+		// routine that derails (e.g. runs off into non-code memory and never
+		// executes the trap instruction) turns this into an unbounded spin
+		// at 100% CPU with no way for the user to recover short of killing
+		// the process (FFX-2's Crimson Squad hits this). Cap the
+		// wait so a misbehaving handler is abandoned instead of hanging
+		// for ever - real handlers return within a tiny fraction of this.
+		uint64_t softcall_cycles = 0;
+		while (!softcall_target)
+		{
+			softcall_cycles += mips_execute(10);
+			if (softcall_cycles > 10000)
+			{
+				fprintf(stderr, "IOP: ERROR! IRQ handler at %08x never returned - abandoning softcall\n", routine);
+				break;
+			}
+		}
 	}
 	mips_set_icount(oldICount);
 
@@ -1056,9 +1072,18 @@ static void psx_bios_exception(uint32_t pc)
 
 					softcall_target = 0;
 					oldICount = mips_get_icount();
-					while (!softcall_target)
 					{
-						mips_execute(10);
+						// See the matching comment in call_irq_routine().
+						uint64_t softcall_cycles = 0;
+						while (!softcall_target)
+						{
+							softcall_cycles += mips_execute(10);
+							if (softcall_cycles > 10000)
+							{
+								fprintf(stderr, "IOP: ERROR! VBlank handler never returned - abandoning softcall\n");
+								break;
+							}
+						}
 					}
 					mips_set_icount(oldICount);
 
@@ -1088,9 +1113,18 @@ static void psx_bios_exception(uint32_t pc)
 
 							softcall_target = 0;
 							oldICount = mips_get_icount();
-							while (!softcall_target)
 							{
-								mips_execute(10);
+								// See the matching comment in call_irq_routine().
+								uint64_t softcall_cycles = 0;
+								while (!softcall_target)
+								{
+									softcall_cycles += mips_execute(10);
+									if (softcall_cycles > 10000)
+									{
+										fprintf(stderr, "IOP: ERROR! root counter %d handler never returned - abandoning softcall\n", i);
+										break;
+									}
+								}
 							}
 							mips_set_icount(oldICount);
 

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -2675,6 +2675,13 @@ static void psx_iop_call_impl(uint32_t pc, uint32_t callnum)
 					if ((threads[i].iState == TS_WAITSEMA) && (threads[i].waitparm == a0))
 					{
 						threads[i].iState = TS_READY;
+						// The woken thread's own WaitSema call is finally
+						// completing successfully - set its saved $v0
+						// directly (it's not the live/current thread right
+						// now), so it sees the correct return value once
+						// actually thawed. See WaitSema's own comment for
+						// why this can no longer be set from there.
+						threads[i].save_regs[2] = 0;
 						semaphores[a0].threadsWaiting--;
 						foundthread = 1;
 						break;
@@ -2709,6 +2716,8 @@ static void psx_iop_call_impl(uint32_t pc, uint32_t callnum)
 					if ((threads[i].iState == TS_WAITSEMA) && (threads[i].waitparm == a0))
 					{
 						threads[i].iState = TS_READY;
+						// See the matching comment in SignalSema.
+						threads[i].save_regs[2] = 0;
 						semaphores[a0].threadsWaiting--;
 						foundthread = 1;
 						break;
@@ -2741,17 +2750,24 @@ static void psx_iop_call_impl(uint32_t pc, uint32_t callnum)
 				if (semaphores[a0].current > 0)
 				{
 					semaphores[a0].current--;
+
+					mipsinfo.i = 0;
+					mips_set_info(CPUINFO_INT_REGISTER + MIPS_R2, &mipsinfo);
 				}
 				else
 				{
+					// Don't set $v0 here: ps2_reschedule() may already have
+					// switched mipscpu to a completely different thread, in
+					// which case this would silently stomp whatever THAT
+					// thread was doing instead of the one that actually
+					// called WaitSema. The blocked thread's own return value
+					// is set directly on its saved state by SignalSema/
+					// iSignalSema when it's actually woken, instead.
 					FreezeThread(iCurThread, 1);
 					threads[iCurThread].iState = TS_WAITSEMA;
 					threads[iCurThread].waitparm = a0;
 					ps2_reschedule();
 				}
-
-				mipsinfo.i = 0;
-				mips_set_info(CPUINFO_INT_REGISTER + MIPS_R2, &mipsinfo);
 				break;
 
 			default:

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -263,6 +263,34 @@ static void FreezeThread(int32_t iThread, int flag)
 	}
 	threads[iThread].save_regs[34] = mipsinfo.i;
 
+	// Every HLE syscall that can freeze its own thread (flag=1) is only
+	// ever reached through psx_iop_call(), which is itself only ever
+	// invoked from the interpreter's "addiu $0,N with rt==0" special case
+	// - and by this codebase's own generated-code convention, that
+	// instruction is always the delay slot of an immediately-preceding
+	// "jr $ra" (the return half of every IOP export-table stub: "jr $ra;
+	// addiu $0,callnum"). So whenever a blocking syscall (DelayThread,
+	// WaitSema, SleepThread, etc.) fires from exactly this position,
+	// mipscpu.delayr is already REGPC (a still-uncommitted pending branch
+	// from that jr) and mipscpu.delayv already equals $ra - the same
+	// value just captured above into save_regs[34]. The delayr/delayv
+	// snapshot taken above therefore describes a branch that's redundant
+	// with the resume PC we're about to restore on thaw, not a second,
+	// independent piece of state: left in place, ThawThread() correctly
+	// sets PC to save_regs[34] but ALSO restores this stale "still
+	// pending" branch, which then wrongly re-fires on the very next
+	// instruction's delay-slot commit instead of letting execution
+	// advance normally - silently diverting control flow into whatever
+	// memory that references, including non-code data if the resumed
+	// thread wasn't expecting a jump there at all. Clear it in this
+	// specific, provably-safe case - the resume PC already captures its
+	// effect.
+	if (flag && threads[iThread].save_regs[36] == 32)	// 32 == psx.cc's REGPC sentinel, not exposed via psx.h
+	{
+		threads[iThread].save_regs[35] = 0;
+		threads[iThread].save_regs[36] = 0;
+	}
+
 	#if DEBUG_THREADING
 	{
 		char buffer[256];

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -142,6 +142,16 @@ typedef struct
 	uint32_t waitparm;	// what we're waiting on if in one the TS_WAIT* states
 
 	uint32_t save_regs[37];	// CPU registers belonging to this thread
+
+	// Which FreezeThread() flag last froze this thread: 1 means its real
+	// resume point is $ra (save_regs[34] already correct, independent of
+	// whatever pc/delayr the interpreter happened to be sitting on); 0
+	// means save_regs[34] is exactly whatever mipscpu.pc was at freeze
+	// time, which - if this thread was mid-HLE-dispatch - can be a
+	// still-pending "target-4" jump the caller's own mips_advance_pc()
+	// hasn't yet completed with a final +4 (see psx_iop_call()'s wrapper
+	// in this file for why this distinction matters).
+	int32_t lastFreezeFlag;
 } Thread;
 
 static int32_t iNumThreads, iCurThread;
@@ -290,6 +300,13 @@ static void FreezeThread(int32_t iThread, int flag)
 		threads[iThread].save_regs[35] = 0;
 		threads[iThread].save_regs[36] = 0;
 	}
+
+	// Record which kind of freeze this was - see the Thread struct's own
+	// comment on lastFreezeFlag for why psx_iop_call()'s wrapper needs
+	// this to decide whether a deferred HLE-dispatch "+4" still needs
+	// completing for this specific thread after control has moved on to
+	// someone else.
+	threads[iThread].lastFreezeFlag = flag;
 
 	#if DEBUG_THREADING
 	{
@@ -2188,7 +2205,7 @@ static void iop_sprintf(char *out, char *fmt, uint32_t pstart)
 }
 
 // PS2 IOP callbacks
-void psx_iop_call(uint32_t pc, uint32_t callnum)
+static void psx_iop_call_impl(uint32_t pc, uint32_t callnum)
 {
 	uint32_t scan;
 	char *mname, *str1, name[9], out[512];
@@ -3577,5 +3594,66 @@ void psx_iop_call(uint32_t pc, uint32_t callnum)
 
 		printf("IOP: Unhandled service %d for module %s\n", callnum, name);
 	}
+}
+
+// psx_iop_call_impl()'s registered-library and ELF-loader dispatch paths
+// (search this file for "NOTE: we get called in the delay slot!") set
+// mipscpu's PC to (target - 4), deliberately relying on the caller
+// (psx.cc's OP_ADDIU case) to complete the jump with its own subsequent
+// mips_advance_pc() call, which adds the final +4. That works as long as
+// mipscpu still belongs to the SAME thread that made this call by the
+// time the caller's advance runs.
+//
+// But psx_iop_call_impl() can also, via a blocking syscall (DelayThread,
+// WaitSema, SleepThread, etc.) OR via any HLE handler that itself calls
+// ps2_reschedule() as routine bookkeeping (e.g. waking a higher-priority
+// thread), end up freezing the calling thread and switching to a
+// DIFFERENT one entirely - at which point mipscpu belongs to that other
+// thread, not the caller. Blindly letting the caller's mips_advance_pc()
+// run in that case corrupts whichever thread is now active (this is what
+// permanently truncated Vegnagun Starting's table-copy loop: the extra
+// advance skipped that thread's own pending loop-continuation branch
+// without ever evaluating it). But blindly SKIPPING the caller's advance
+// whenever any switch happens is ALSO wrong (this was tried and caused
+// total silence): if the calling thread got frozen via the generic
+// flag=0 path (not a $ra-based blocking syscall), its OWN saved PC is
+// exactly the pending "target-4" state above, still missing its +4 - and
+// if nothing ever completes that +4, the thread resumes 4 bytes short
+// the next time it's thawed.
+//
+// So: track whether a switch happened, and if so, look at how the
+// calling thread was actually frozen (recorded in Thread::lastFreezeFlag
+// by FreezeThread() itself) to decide what to do with ITS OWN saved
+// state specifically, independent of whichever thread is now live:
+//   - flag=1 (syscall/$ra-based): the calling thread's real resume point
+//     is $ra, already fully correct - the pending "target-4" pc doesn't
+//     matter to it at all. Nothing to fix.
+//   - flag=0 (generic/pc-based): the calling thread's saved pc IS the
+//     pending "target-4" state - complete it directly on its saved
+//     registers, since mipscpu no longer represents it.
+// Either way, tell the caller NOT to run its own mips_advance_pc(), since
+// mipscpu now belongs to a different thread than the one that made this
+// call, and that thread's own execution must not be touched by it.
+uint32_t psx_iop_call(uint32_t pc, uint32_t callnum)
+{
+	int32_t origThread = iCurThread;
+
+	psx_iop_call_impl(pc, callnum);
+
+	if (iCurThread == origThread)
+	{
+		// No net switch away from the calling thread (including having
+		// been frozen and thawed straight back to itself) - mipscpu is
+		// still (or once again) its own context, so the caller's normal
+		// mips_advance_pc() applies correctly, exactly as before.
+		return 1;
+	}
+
+	if (origThread >= 0 && threads[origThread].lastFreezeFlag == 0)
+	{
+		threads[origThread].save_regs[34] += 4;
+	}
+
+	return 0;
 }
 

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -1982,9 +1982,15 @@ void psx_hw_runcounters(void)
 		{
 			if (threads[i].iState == TS_WAITDELAY)
 			{
-				if (threads[i].waitparm > CLOCK_DIV)
+				// waitparm is set (in DelayThread) in raw IOP clock
+				// cycles at the true 36864000 Hz rate; each sample
+				// represents IOP_CYCLES_PER_SAMPLE of those, not
+				// CLOCK_DIV - the latter was off by ~104x, making
+				// every delay-based wait take that much longer than
+				// requested.
+				if (threads[i].waitparm > IOP_CYCLES_PER_SAMPLE)
 				{
-					threads[i].waitparm -= CLOCK_DIV;
+					threads[i].waitparm -= IOP_CYCLES_PER_SAMPLE;
 				}
 				else	// time's up
 				{

--- a/src/psf/psx_hw.cc
+++ b/src/psf/psx_hw.cc
@@ -137,7 +137,11 @@ typedef struct
 	uint32_t routine;		// start of code for the thread
 	uint32_t stackloc;	// stack location in IOP RAM
 	uint32_t stacksize;	// stack size
-	uint32_t refCon;		// user value passed in at CreateThread time
+	// IOP thread priority as passed to CreateThread (lower = more urgent,
+	// matching real PS2 IOP convention). Previously read into an unused
+	// "refCon" field and never consulted - ps2_reschedule() now uses it
+	// to pick the most urgent ready thread instead of pure round-robin.
+	uint32_t priority;
 
 	uint32_t waitparm;	// what we're waiting on if in one the TS_WAIT* states
 
@@ -383,6 +387,7 @@ static void ThawThread(int32_t iThread)
 static void ps2_reschedule(void)
 {
 	int i, starti, iNextThread;
+	uint32_t bestPriority = 0xffffffff;
 
 	iNextThread = -1;
 
@@ -395,36 +400,53 @@ static void ps2_reschedule(void)
 
 	starti = i;
 
-	// starting with the next thread after this one,
-	// see who wants to run
+	// Starting with the next thread after this one, scan the whole
+	// thread list (wrapping around) for the most urgent (lowest
+	// priority value) ready thread. Round-robin scan order is the
+	// tie-break among equal priorities (strict "<" below means an
+	// equal-priority later candidate never displaces an earlier one),
+	// matching prior behavior when priority doesn't distinguish them.
 	while (i < iNumThreads)
 	{
 		if (i != iCurThread)
 		{
-			if (threads[i].iState == TS_READY)
+			if (threads[i].iState == TS_READY && threads[i].priority < bestPriority)
 			{
 			  	iNextThread = i;
-				break;
+				bestPriority = threads[i].priority;
 			}
 		}
 
 		i++;
 	}
 
-	// if we started above thread 0 and didn't pick one,
-	// go around and try from zero
-	if ((starti > 0) && (iNextThread == -1))
+	if (starti > 0)
 	{
-		for (i = 0; i < iNumThreads; i++)
+		for (i = 0; i < starti; i++)
 		{
 			if (i != iCurThread)
 			{
-				if (threads[i].iState == TS_READY)
+				if (threads[i].iState == TS_READY && threads[i].priority < bestPriority)
 				{
 				  	iNextThread = i;
-					break;
+					bestPriority = threads[i].priority;
 				}
 			}
+		}
+	}
+
+	// A thread that's still actively running (hasn't voluntarily
+	// blocked/slept/exited before this call) only yields to a
+	// STRICTLY more urgent candidate - an equal-or-less-urgent ready
+	// thread waits its turn instead of preempting mid-work. A thread
+	// that already left TS_RUNNING (blocked itself before calling
+	// this) still switches to the best available candidate
+	// unconditionally, same as prior behavior for that case.
+	if (iNextThread != -1 && iCurThread != -1 && threads[iCurThread].iState == TS_RUNNING)
+	{
+		if (bestPriority >= threads[iCurThread].priority)
+		{
+			iNextThread = -1;
 		}
 	}
 
@@ -2345,7 +2367,7 @@ static void psx_iop_call_impl(uint32_t pc, uint32_t callnum)
 				threads[iNumThreads].flags = LE32(psx_ram[a0]);
 				threads[iNumThreads].routine = LE32(psx_ram[a0+2]);
 				threads[iNumThreads].stacksize = LE32(psx_ram[a0+3]);
-				threads[iNumThreads].refCon = LE32(psx_ram[a0+4]);
+				threads[iNumThreads].priority = LE32(psx_ram[a0+4]);
 
 				mipsinfo.i = iNumThreads;
 				iNumThreads++;


### PR DESCRIPTION
The full explanation for this is in https://github.com/orgs/audacious-media-player/discussions/1867.

But essentially, I found these LLM-assisted changes were necessary to resolve serious issues I found with OpenPSF:
* Missing instruments in several tracks, notably Final Fantasy X-2's 'Yuna's Theme', 'Mission Complete', 'Destruction', and Final Fantasy XI: Rise of the Zilart's 'Dash de Chocobo'.
* An overflow that resulted in a horrible screeching replacing a pipe organ instrument in Final Fantasy X-2's 'Vegnagun Starting'.
* Final Fantasy X-2's 'Crimson Squad' would hang in a way that requires Audacious to be force-killed.
* A pause after the first beat of Final Fantasy XI: Treasures of Aht Urghan's 'Run Chocobo Run!'
* A drop-silence heuristic that masked a start-up silence delay caused by idle processing, but also caused serious issues with some tracks, most notably Final Fantasy X-2's 'Chocobo'.

Unsolved:
* Handling of Final Fantasy IV's PS2 streaming driver has improved (no longer halts after a split second of playback) but still doesn't work correctly.
* Final Fantasy X cannot be decoded - the entire set remains silent (but no longer causes Audacious to hang in a way that requires a force-kill).
* The start-up silence exposed as a side-effect of removing the drop-silence heuristic is mitigated by implementation of scheduler fairness but not fully resolved.

Only the PS2 portion is affected by this, PS1 portion is untouched.

All of this may become moot if a better implementation is brought in to replace OpenPSF, as discussed in the thread linked at the start.