### PR TITLE
scrobbler2, streamtuner: honor the configured proxy settings

### DIFF
--- a/src/scrobbler2/scrobbler_communication.cc
+++ b/src/scrobbler2/scrobbler_communication.cc
@@ -29,6 +29,11 @@ typedef struct {
 
 static CURL *curlHandle = nullptr;     //global handle holding cURL options
 
+// tracks whether we set proxy options on the curl handle ourselves,
+// so that disabling the proxy in the preferences takes effect
+// without clobbering libcurl's default (environment variable) handling
+static bool proxy_applied = false;
+
 gboolean scrobbling_enabled = true;
 
 //shared variables
@@ -120,9 +125,70 @@ static String create_message_to_lastfm (const char * method_name, int n_args, ..
     return String (buf);
 }
 
+static void apply_proxy_settings ()
+{
+    if (! aud_get_bool ("use_proxy"))
+    {
+        if (proxy_applied)
+        {
+            curl_easy_setopt (curlHandle, CURLOPT_PROXY, "");
+            curl_easy_setopt (curlHandle, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+            curl_easy_setopt (curlHandle, CURLOPT_PROXYUSERNAME, nullptr);
+            curl_easy_setopt (curlHandle, CURLOPT_PROXYPASSWORD, nullptr);
+            proxy_applied = false;
+        }
+        return;
+    }
+
+    String proxy_host = aud_get_str ("proxy_host");
+    if (! proxy_host || ! proxy_host[0])
+    {
+        if (proxy_applied)
+        {
+            curl_easy_setopt (curlHandle, CURLOPT_PROXY, "");
+            proxy_applied = false;
+        }
+        return;
+    }
+
+    AUDDBG ("Using proxy: %s:%d\n", (const char *) proxy_host,
+     aud_get_int ("proxy_port"));
+
+    proxy_applied = true;
+
+    curl_easy_setopt (curlHandle, CURLOPT_PROXY, (const char *) proxy_host);
+    curl_easy_setopt (curlHandle, CURLOPT_PROXYPORT,
+     (long) aud_get_int ("proxy_port"));
+
+    if (aud_get_bool ("socks_proxy"))
+    {
+        curl_easy_setopt (curlHandle, CURLOPT_PROXYTYPE,
+         aud_get_int ("socks_type") == 0 ? CURLPROXY_SOCKS4A : CURLPROXY_SOCKS5);
+    }
+    else
+        curl_easy_setopt (curlHandle, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+
+    if (aud_get_bool ("use_proxy_auth"))
+    {
+        String proxy_user = aud_get_str ("proxy_user");
+        String proxy_pass = aud_get_str ("proxy_pass");
+
+        curl_easy_setopt (curlHandle, CURLOPT_PROXYUSERNAME, (const char *) proxy_user);
+        curl_easy_setopt (curlHandle, CURLOPT_PROXYPASSWORD, (const char *) proxy_pass);
+    }
+    else
+    {
+        /* clear credentials possibly set earlier, so that toggling
+         * "use authentication with proxy" off takes effect immediately */
+        curl_easy_setopt (curlHandle, CURLOPT_PROXYUSERNAME, nullptr);
+        curl_easy_setopt (curlHandle, CURLOPT_PROXYPASSWORD, nullptr);
+    }
+}
+
 static gboolean send_message_to_lastfm (const char * data)
 {
     AUDDBG("This message will be sent to last.fm:\n%s\n%%%%End of message%%%%\n", data);//Enter?\n", data);
+    apply_proxy_settings ();
     curl_easy_setopt(curlHandle, CURLOPT_POSTFIELDS, data);
     CURLcode curl_requests_result = curl_easy_perform(curlHandle);
 
@@ -269,6 +335,9 @@ gboolean scrobbler_communication_init() {
         AUDDBG("Could not initialize libCURL.\n");
         return false;
     }
+
+    // the fresh handle carries no proxy options yet
+    proxy_applied = false;
 
     curl_requests_result = curl_easy_setopt(curlHandle, CURLOPT_URL, SCROBBLER_URL);
     if (curl_requests_result != CURLE_OK) {

--- a/src/streamtuner/shoutcast-model.cc
+++ b/src/streamtuner/shoutcast-model.cc
@@ -21,6 +21,7 @@
 
 #include <QAbstractListModel>
 #include <QNetworkAccessManager>
+#include <QNetworkProxy>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QJsonDocument>
@@ -29,10 +30,41 @@
 
 #include "shoutcast-model.h"
 
+/* applies the proxy settings from the Network preferences page */
+static void apply_proxy_settings (QNetworkAccessManager * qnam)
+{
+    if (! aud_get_bool ("use_proxy"))
+        return;
+
+    String host = aud_get_str ("proxy_host");
+
+    if (! host || ! host[0])
+        return;
+
+    QNetworkProxy proxy;
+
+    /* note: Qt supports SOCKS5 only; most SOCKS v4a servers
+     * accept SOCKS5 clients as well */
+    proxy.setType (aud_get_bool ("socks_proxy") ?
+     QNetworkProxy::Socks5Proxy : QNetworkProxy::HttpProxy);
+    proxy.setHostName (QString (host));
+    proxy.setPort (aud_get_int ("proxy_port"));
+
+    if (aud_get_bool ("use_proxy_auth"))
+    {
+        proxy.setUser (QString (aud_get_str ("proxy_user")));
+        proxy.setPassword (QString (aud_get_str ("proxy_pass")));
+    }
+
+    qnam->setProxy (proxy);
+}
+
 ShoutcastTunerModel::ShoutcastTunerModel (QObject * parent) :
     QAbstractListModel (parent)
 {
     m_qnam = new QNetworkAccessManager (this);
+
+    apply_proxy_settings (m_qnam);
 
     fetch_stations ();
 }


### PR DESCRIPTION
The scrobbler (last.fm) plugin and the Shoutcast directory model talked to the network directly (libcurl and QNetworkAccessManager respectively) and ignored the proxy configured on the Network preferences page.  Apply the use_proxy/proxy_host/proxy_port/ use_proxy_auth/proxy_user/proxy_pass/socks_proxy/socks_type settings in both places, matching what the neon and cdaudio plugins already do.

To access last.fm via proxy before this change, it was needed to do like this:

```$ https_proxy=socks5://localhost:4646 audacious```

For libcurl the settings are (re)applied before each request so that changes in the preferences take effect without restarting; when the proxy is disabled the options we set are reset, leaving libcurl's default environment-variable handling untouched.

Qt only supports SOCKS5, so the SOCKS v4a option is mapped to Socks5Proxy (most SOCKS servers accept both).

Proxy precedence after this change:

  - scrobbler2 (libcurl): the Audacious settings win when enabled (an explicitly set CURLOPT_PROXY always overrides libcurl's environment handling); when the proxy is disabled and was never enabled, libcurl keeps honoring https_proxy from the environment (unchanged behavior); toggling the proxy off in the preferences resets the options we set, which also disables env-based proxies from that point on.

  - streamtuner/shoutcast (QNetworkAccessManager): Qt never reads *_proxy environment variables, so the Audacious settings are the only source; disabled means a direct connection.

  - neon (streams, and everything going through VFS: icecast, iHeart, lyrics, ampache, album art): libneon has no environment proxy support; only the Audacious settings apply, as before.

Tested with last.fm.

Co-authored-by: Kimi AI